### PR TITLE
Add option to compile salva2d with wasm-bindgen

### DIFF
--- a/build/salva2d/Cargo.toml
+++ b/build/salva2d/Cargo.toml
@@ -12,11 +12,12 @@ license = "BSD-3-Clause"
 edition = "2018"
 
 [features]
-default = [ "dim2" ]
+default = [ "dim2", "stdweb", "nphysics2d/default", "instant/stdweb" ]
 dim2    = [ ]
 parallel = [ "rayon" ]
 nphysics = [ "ncollide2d", "nphysics2d" ]
 sampling = [ "ncollide2d" ]
+use-wasm-bindgen = [ "dim2", "wasm-bindgen", "web-sys", "nphysics2d/use-wasm-bindgen", "instant/wasm-bindgen" ]
 
 [lib]
 name = "salva2d"
@@ -32,4 +33,9 @@ nalgebra  = "0.21"
 instant = { version = "0.1", features = [ "now" ] }
 rayon = { version = "1.0", optional = true }
 ncollide2d = { version = "0.23", optional = true }
-nphysics2d = { version = "0.16", optional = true }
+nphysics2d = { version = "0.16", optional = true, default-features = false }
+
+[target.wasm32-unknown-unknown.dependencies]
+stdweb = {version = "0.4", optional = true}
+wasm-bindgen = {version = "0.2", optional = true}
+web-sys = {version = "0.3", optional = true, features = ['Window', 'Performance', 'PerformanceTiming']}


### PR DESCRIPTION
Right now, salva2d only compiles with stdweb. Future momentum seems to be [moving towards wasm-bindgen](https://github.com/rustwasm/team/issues/226), so adding support like e.g. nphysics has seems natural.

I followed the same strategy used in nphysics (see their [Cargo.toml](https://github.com/rustsim/nphysics/blob/master/build/nphysics2d/Cargo.toml)). By default, the salva crate uses stdweb to preserve compatibility. A user of salva can switch to wasm-bindgen like so:

```toml
salva2d = { version = "whatever", default-features = false, features = ["use-wasm-bindgen"] }
```

If y'all are ok with this strategy, I can copy it over to `salva3d` as well.