### PR TITLE
add particles_intersecting_aabb method to Fluid & LiquidWorld

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ rapier2d = { git = "https://github.com/dimforge/rapier" }
 rapier3d = { git = "https://github.com/dimforge/rapier" }
 rapier_testbed2d = { git = "https://github.com/dimforge/rapier" }
 rapier_testbed3d = { git = "https://github.com/dimforge/rapier" }
+ncollide2d = { git = "https://github.com/dimforge/ncollide" }
+ncollide3d = { git = "https://github.com/dimforge/ncollide" }
 
 #rapier2d = { path = "../rapier/build/rapier2d" }
 #rapier3d = { path = "../rapier/build/rapier3d" }

--- a/build/salva2d/Cargo.toml
+++ b/build/salva2d/Cargo.toml
@@ -36,4 +36,4 @@ rayon = { version = "1.5", optional = true }
 ncollide2d = { version = "0.26", optional = true }
 rapier2d = { version = "0.3", optional = true }
 rapier_testbed2d = { version = "0.3", optional = true }
-kiss3d = { version = "0.27", optional = true }
+kiss3d = { version = "0.28", optional = true }

--- a/build/salva3d/Cargo.toml
+++ b/build/salva3d/Cargo.toml
@@ -36,4 +36,4 @@ rayon = { version = "1.5", optional = true }
 ncollide3d = { version = "0.26", optional = true }
 rapier3d = { version = "0.3", optional = true }
 rapier_testbed3d = { version = "0.3", optional = true }
-kiss3d = { version = "0.27", optional = true }
+kiss3d = { version = "0.28", optional = true }

--- a/examples3d/Cargo.toml
+++ b/examples3d/Cargo.toml
@@ -12,7 +12,7 @@ num-traits = "0.2"
 Inflector  = "0.11"
 nalgebra   = "0.23"
 ncollide3d = "0.26"
-kiss3d     = "0.27"
+kiss3d     = "0.28"
 rapier3d = "0.3"
 rapier_testbed3d = "0.3"
 

--- a/src/liquid_world.rs
+++ b/src/liquid_world.rs
@@ -173,7 +173,7 @@ impl LiquidWorld {
         self.boundaries.remove(handle)
     }
 
-    // #[cfg(feature = "dim3")]
+    /// get all particles within the given AABB
     pub fn particles_intersecting_aabb(&self, aabb: &AABB<Real>) -> Vec<Point<Real>> {
         self.fluids
             .iter()

--- a/src/liquid_world.rs
+++ b/src/liquid_world.rs
@@ -1,11 +1,12 @@
 use crate::counters::Counters;
 use crate::coupling::CouplingManager;
 use crate::geometry::{self, ContactManager, HGrid, HGridEntry};
-use crate::math::{Real, Vector};
+use crate::math::{Point, Real, Vector};
 use crate::object::{Boundary, BoundaryHandle, BoundarySet};
 use crate::object::{Fluid, FluidHandle, FluidSet};
 use crate::solver::PressureSolver;
 use crate::TimestepManager;
+use kiss3d::ncollide3d::bounding_volume::AABB;
 
 /// The physics world for simulating fluids with boundaries.
 pub struct LiquidWorld {
@@ -169,6 +170,15 @@ impl LiquidWorld {
     /// Add a boundary to the liquid world.
     pub fn remove_boundary(&mut self, handle: BoundaryHandle) -> Option<Boundary> {
         self.boundaries.remove(handle)
+    }
+
+    #[cfg(feature = "dim3")]
+    pub fn particles_intersecting_aabb(&self, aabb: &AABB<Real>) ->Vec<Point<Real>> {
+        self
+            .fluids
+            .iter()
+            .flat_map(|(_, fluid)| fluid.particles_intersecting_aabb(aabb))
+            .collect()
     }
 
     /// The set of fluids on this liquid world.

--- a/src/liquid_world.rs
+++ b/src/liquid_world.rs
@@ -6,7 +6,8 @@ use crate::object::{Boundary, BoundaryHandle, BoundarySet};
 use crate::object::{Fluid, FluidHandle, FluidSet};
 use crate::solver::PressureSolver;
 use crate::TimestepManager;
-use kiss3d::ncollide3d::bounding_volume::AABB;
+
+use ncollide::bounding_volume::AABB;
 
 /// The physics world for simulating fluids with boundaries.
 pub struct LiquidWorld {
@@ -172,7 +173,7 @@ impl LiquidWorld {
         self.boundaries.remove(handle)
     }
 
-    #[cfg(feature = "dim3")]
+    // #[cfg(feature = "dim3")]
     pub fn particles_intersecting_aabb(&self, aabb: &AABB<Real>) -> Vec<Point<Real>> {
         self.fluids
             .iter()

--- a/src/liquid_world.rs
+++ b/src/liquid_world.rs
@@ -173,9 +173,8 @@ impl LiquidWorld {
     }
 
     #[cfg(feature = "dim3")]
-    pub fn particles_intersecting_aabb(&self, aabb: &AABB<Real>) ->Vec<Point<Real>> {
-        self
-            .fluids
+    pub fn particles_intersecting_aabb(&self, aabb: &AABB<Real>) -> Vec<Point<Real>> {
+        self.fluids
             .iter()
             .flat_map(|(_, fluid)| fluid.particles_intersecting_aabb(aabb))
             .collect()

--- a/src/object/fluid.rs
+++ b/src/object/fluid.rs
@@ -2,8 +2,8 @@ use crate::math::{Isometry, Point, Real, Vector};
 use crate::object::{ContiguousArena, ContiguousArenaIndex};
 use crate::solver::NonPressureForce;
 
-use num::Zero;
 use kiss3d::ncollide3d::bounding_volume::AABB;
+use num::Zero;
 
 /// A fluid object.
 ///
@@ -192,11 +192,10 @@ impl Fluid {
     /// return all particles within the given AABB
     #[cfg(feature = "dim3")]
     pub fn particles_intersecting_aabb(&self, aabb: &AABB<Real>) -> Vec<Point<Real>> {
-        self
-            .positions
+        self.positions
             .iter()
             .filter(|particle| aabb.contains_local_point(*particle))
-            .map(|particle|*particle)
+            .map(|particle| *particle)
             .collect()
     }
 }

--- a/src/object/fluid.rs
+++ b/src/object/fluid.rs
@@ -3,6 +3,7 @@ use crate::object::{ContiguousArena, ContiguousArenaIndex};
 use crate::solver::NonPressureForce;
 
 use num::Zero;
+use kiss3d::ncollide3d::bounding_volume::AABB;
 
 /// A fluid object.
 ///
@@ -186,6 +187,17 @@ impl Fluid {
         } else {
             na::one::<Real>() / (self.volumes[i] * self.density0)
         }
+    }
+
+    /// return all particles within the given AABB
+    #[cfg(feature = "dim3")]
+    pub fn particles_intersecting_aabb(&self, aabb: &AABB<Real>) -> Vec<Point<Real>> {
+        self
+            .positions
+            .iter()
+            .filter(|particle| aabb.contains_local_point(*particle))
+            .map(|particle|*particle)
+            .collect()
     }
 }
 

--- a/src/object/fluid.rs
+++ b/src/object/fluid.rs
@@ -189,8 +189,7 @@ impl Fluid {
         }
     }
 
-    /// return all particles within the given AABB
-    // #[cfg(feature = "dim3")]
+    /// get all particles within the given AABB
     pub fn particles_intersecting_aabb(&self, aabb: &AABB<Real>) -> Vec<Point<Real>> {
         self.positions
             .iter()

--- a/src/object/fluid.rs
+++ b/src/object/fluid.rs
@@ -2,7 +2,7 @@ use crate::math::{Isometry, Point, Real, Vector};
 use crate::object::{ContiguousArena, ContiguousArenaIndex};
 use crate::solver::NonPressureForce;
 
-use kiss3d::ncollide3d::bounding_volume::AABB;
+use ncollide::bounding_volume::AABB;
 use num::Zero;
 
 /// A fluid object.
@@ -190,7 +190,7 @@ impl Fluid {
     }
 
     /// return all particles within the given AABB
-    #[cfg(feature = "dim3")]
+    // #[cfg(feature = "dim3")]
     pub fn particles_intersecting_aabb(&self, aabb: &AABB<Real>) -> Vec<Point<Real>> {
         self.positions
             .iter()


### PR DESCRIPTION
Fixes #10.

This feature is gated to dim3 feature, is the AABB struct 3d-only? I couldnt get it working unless it was gated to the dim3 feature.

This adds differing code depending on the dimension, which I imagine you would like to minimize?

Thanks!