### PR TITLE
Add methods to retrieve all the particles intersecting an AABB or a shape.

### DIFF
--- a/build/salva2d/Cargo.toml
+++ b/build/salva2d/Cargo.toml
@@ -15,9 +15,10 @@ edition = "2018"
 default = [ "dim2" ]
 dim2    = [ ]
 parallel = [ "rayon" ]
-sampling = [ "ncollide2d" ]
-rapier = [ "ncollide2d", "rapier2d" ]
+sampling = [ "ncollide" ]
+rapier = [ "ncollide", "rapier2d" ]
 rapier-testbed = [ "rapier", "rapier_testbed2d", "kiss3d" ]
+ncollide = [ "ncollide2d" ]
 
 [lib]
 name = "salva2d"

--- a/build/salva2d/Cargo.toml
+++ b/build/salva2d/Cargo.toml
@@ -36,4 +36,4 @@ rayon = { version = "1.5", optional = true }
 ncollide2d = { version = "0.26", optional = true }
 rapier2d = { version = "0.3", optional = true }
 rapier_testbed2d = { version = "0.3", optional = true }
-kiss3d = { version = "0.27", optional = true }
+kiss3d = { version = "0.28", optional = true }

--- a/build/salva3d/Cargo.toml
+++ b/build/salva3d/Cargo.toml
@@ -15,9 +15,10 @@ edition = "2018"
 default = [ "dim3" ]
 dim3    = [ ]
 parallel = [ "rayon" ]
-rapier = [ "ncollide3d", "rapier3d" ]
-sampling = [ "ncollide3d" ]
+rapier = [ "ncollide", "rapier3d" ]
+sampling = [ "ncollide" ]
 rapier-testbed = [ "rapier", "rapier_testbed3d", "kiss3d" ]
+ncollide = [ "ncollide3d" ]
 
 [lib]
 name = "salva3d"

--- a/build/salva3d/Cargo.toml
+++ b/build/salva3d/Cargo.toml
@@ -36,4 +36,4 @@ rayon = { version = "1.5", optional = true }
 ncollide3d = { version = "0.26", optional = true }
 rapier3d = { version = "0.3", optional = true }
 rapier_testbed3d = { version = "0.3", optional = true }
-kiss3d = { version = "0.27", optional = true }
+kiss3d = { version = "0.28", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,9 +36,9 @@ The name of this library is inspired from the famous surrealist artist `Salvador
 #![doc(html_logo_url = "https://salva.rs/img/logo_salva_rustdoc.svg")]
 
 extern crate nalgebra as na;
-#[cfg(all(feature = "dim2", feature = "ncollide2d"))]
+#[cfg(all(feature = "dim2", feature = "ncollide"))]
 extern crate ncollide2d as ncollide;
-#[cfg(all(feature = "dim3", feature = "ncollide3d"))]
+#[cfg(all(feature = "dim3", feature = "ncollide"))]
 extern crate ncollide3d as ncollide;
 extern crate num_traits as num;
 #[cfg(all(feature = "dim2", feature = "rapier"))]

--- a/src/liquid_world.rs
+++ b/src/liquid_world.rs
@@ -6,9 +6,12 @@ use crate::object::{Boundary, BoundaryHandle, BoundarySet};
 use crate::object::{Fluid, FluidHandle, FluidSet, ParticleId};
 use crate::solver::PressureSolver;
 use crate::TimestepManager;
-use ncollide::bounding_volume::{HasBoundingVolume, AABB};
-use ncollide::query::PointQuery;
-use ncollide::shape::Cuboid;
+#[cfg(feature = "ncollide")]
+use ncollide::{
+    bounding_volume::{HasBoundingVolume, AABB},
+    query::PointQuery,
+    shape::Cuboid,
+};
 
 /// The physics world for simulating fluids with boundaries.
 pub struct LiquidWorld {
@@ -205,6 +208,7 @@ impl LiquidWorld {
     }
 
     /// The set of particles potentially intersecting the given AABB.
+    #[cfg(feature = "ncollide")]
     pub fn particles_intersecting_aabb<'a>(
         &'a self,
         aabb: &'a AABB<f32>,
@@ -239,6 +243,7 @@ impl LiquidWorld {
     }
 
     /// The set of particles potentially intersecting the given AABB.
+    #[cfg(feature = "ncollide")]
     pub fn particles_intersecting_shape<'a, S: ?Sized>(
         &'a self,
         pos: &'a Isometry<f32>,

--- a/src/object/boundary.rs
+++ b/src/object/boundary.rs
@@ -77,7 +77,7 @@ impl Boundary {
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 /// The unique identifier of a boundary object.
 pub struct BoundaryHandle(ContiguousArenaIndex);
-/// A set of all boundary objects.
+/// A set of all boundary objects.
 pub type BoundarySet = ContiguousArena<BoundaryHandle, Boundary>;
 
 impl From<ContiguousArenaIndex> for BoundaryHandle {

--- a/src/object/contiguous_arena.rs
+++ b/src/object/contiguous_arena.rs
@@ -28,6 +28,19 @@ impl<Idx, T> ContiguousArena<Idx, T> {
     }
 
     #[inline]
+    /// Get an element from its position on the contiguous array.
+    pub fn get_from_contiguous_index(&self, index: usize) -> Option<(&T, Idx)>
+    where
+        Idx: From<ContiguousArenaIndex>,
+    {
+        if let (Some(elt), Some(handle)) = (self.objects.get(index), self.rev_indices.get(index)) {
+            Some((elt, Idx::from(*handle)))
+        } else {
+            None
+        }
+    }
+
+    #[inline]
     /// The number of objects on this arena.
     pub fn len(&self) -> usize {
         self.objects.len()

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -10,6 +10,8 @@ mod fluid;
 
 /// The identifier of a single particle.
 pub enum ParticleId {
+    /// A fluid particle.
     FluidParticle(FluidHandle, usize),
+    /// A boundary particle.
     BoundaryParticle(BoundaryHandle, usize),
 }

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -7,3 +7,9 @@ pub use self::fluid::{Fluid, FluidHandle, FluidSet};
 mod boundary;
 mod contiguous_arena;
 mod fluid;
+
+/// The identifier of a single particle.
+pub enum ParticleId {
+    FluidParticle(FluidHandle, usize),
+    BoundaryParticle(BoundaryHandle, usize),
+}


### PR DESCRIPTION
Fix #10
This adds the `LiquidWorld::particles_intersecting_shape` and `LiquidWorld::particles_intersecting_aabb` methods.
This requires the `ncollide` feature of salva to be enabled.