### PR TITLE
depend on salva3d/parallel when parallel feature enables

### DIFF
--- a/examples3d/Cargo.toml
+++ b/examples3d/Cargo.toml
@@ -5,7 +5,7 @@ authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 edition = "2018"
 
 [features]
-parallel = [ "rapier_testbed3d/parallel"]
+parallel = [ "rapier_testbed3d/parallel", "salva3d/parallel"]
 
 [dependencies]
 num-traits = "0.2"


### PR DESCRIPTION
This is needed to get parallel salva working in the examples.