### PR TITLE
Contiguous arena add remove test

### DIFF
--- a/src/object/contiguous_arena.rs
+++ b/src/object/contiguous_arena.rs
@@ -161,3 +161,17 @@ impl<Idx, T> AsMut<[T]> for ContiguousArena<Idx, T> {
         &mut self.objects
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_add_remove() {
+        let mut ca: ContiguousArena<Index, usize> = ContiguousArena::new();
+        let val = 5434;
+        let h = ca.insert(val);
+
+        let out = ca.remove(h);
+        assert_eq!(out, Some(val));
+    }
+}


### PR DESCRIPTION
This adds a test to ContiguousArena to add & remove. This test fails on master.

I'm not sure how to safely fix this, as I'm not too sure what this struct is doing, but the following fixes the panic:

```rust
        if let Some(rev_id) = swapped_rev_id {
            if let Some(indice) = self.indices.get_mut(rev_id) {
                *indice = i;
            }
        }
```