### PR TITLE
Replace  "milliseconds" with "seconds"

### DIFF
--- a/src/integrations/rapier/fluids_pipeline.rs
+++ b/src/integrations/rapier/fluids_pipeline.rs
@@ -40,7 +40,7 @@ impl FluidsPipeline {
         }
     }
 
-    /// Advances the fluid simulation by `dt` milliseconds.
+    /// Advances the fluid simulation by `dt` seconds.
     ///
     /// All the fluid particles will be affected by an acceleration equal to `gravity`.
     /// This `step` function may apply forces to some rigid-bodies that interact with fluids.

--- a/src/liquid_world.rs
+++ b/src/liquid_world.rs
@@ -56,14 +56,14 @@ impl LiquidWorld {
         }
     }
 
-    /// Advances the simulation by `dt` milliseconds.
+    /// Advances the simulation by `dt` seconds.
     ///
     /// All the fluid particles will be affected by an acceleration equal to `gravity`.
     pub fn step(&mut self, dt: Real, gravity: &Vector<Real>) {
         self.step_with_coupling(dt, gravity, &mut ())
     }
 
-    /// Advances the simulation by `dt` milliseconds, taking into account coupling with an external rigid-body engine.
+    /// Advances the simulation by `dt` seconds, taking into account coupling with an external rigid-body engine.
     pub fn step_with_coupling(
         &mut self,
         dt: Real,


### PR DESCRIPTION
...at least I think the `dt` values were meant to be in seconds (values beyond 0.1 tend to diverge quickly)