### PR TITLE
Update to more modern bevy/rapier/parry/nalgebra dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [ "build/salva2d", "build/salva3d", "examples2d", "examples3d" ]
+resolver = "2"
 
 [profile.release]
 #lto = true

--- a/build/salva2d/Cargo.toml
+++ b/build/salva2d/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 categories = [ "science", "game-development", "mathematics", "simulation", "wasm"]
 keywords = [ "physics", "dynamics", "particles", "fluids", "SPH" ]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [badges]
 maintenance = { status = "actively-developed" }
@@ -33,7 +33,7 @@ path = "../../src/lib.rs"
 required-features = [ "dim2" ]
 
 [dependencies]
-approx = "0.4"
+approx = "0.5.1"
 num-traits = "0.2"
 fnv = "1.0"
 itertools = "0.10"
@@ -41,17 +41,16 @@ generational-arena = "0.2"
 instant = { version = "0.1", features = [ "now" ] }
 rayon = { version = "1.5", optional = true }
 
-nalgebra  = "0.29"
-parry2d = { version = "0.7", optional = true }
-rapier2d = { version = "0.11", optional = true }
-rapier_testbed2d = { version = "0.11", optional = true }
+nalgebra = "0.32.2"
+parry2d = { version = "0.13.3", optional = true }
+rapier2d = { version = "0.17.2", optional = true }
+rapier_testbed2d = { version = "0.17", optional = true }
 
-bevy_egui = { version = "0.5", optional = true }
+bevy_egui = { version = "0.18", features = ["immutable_ctx"], optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-bevy = { version = "0.5", default-features = false, features = ["bevy_wgpu", "bevy_winit", "render", "x11"], optional = true }
+bevy = { version = "0.9", default-features = false, features = ["bevy_winit", "bevy_render", "x11"], optional = true }
 
 # Dependencies for WASM only.
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-bevy = { version = "0.5", default-features = false, features = ["bevy_winit", "render"], optional = true }
-bevy_webgl2 = { version = "0.5", optional = true }
+bevy = { version = "0.9", default-features = false, features = ["bevy_winit", "bevy_render"], optional = true }

--- a/build/salva3d/Cargo.toml
+++ b/build/salva3d/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/dimforge/salva"
 readme = "README.md"
 keywords = [ "physics", "dynamics", "particles", "fluids", "SPH" ]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [features]
 default = [ "dim3" ]
@@ -37,18 +37,17 @@ generational-arena = "0.2"
 instant = { version = "0.1", features = [ "now" ] }
 rayon = { version = "1.5", optional = true }
 
-nalgebra  = "0.29"
-parry3d = { version = "0.7", optional = true }
-rapier3d = { version = "0.11", optional = true }
-rapier_testbed3d = { version = "0.11", optional = true }
+nalgebra = "0.32.2"
+parry3d = { version = "0.13.3", optional = true }
+rapier3d = { version = "0.17.2", optional = true }
+rapier_testbed3d = { version = "0.17", optional = true }
 
-bevy_egui = { version = "0.5", optional = true }
+bevy_egui = { version = "0.18", features = ["immutable_ctx"], optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-bevy = { version = "0.5", default-features = false, features = ["bevy_wgpu", "bevy_winit", "render", "x11"], optional = true }
+bevy = { version = "0.9", default-features = false, features = ["bevy_winit", "bevy_render", "x11"], optional = true }
 
 # Dependencies for WASM only.
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-bevy = { version = "0.5", default-features = false, features = ["bevy_winit", "render"], optional = true }
-bevy_webgl2 = { version = "0.5", optional = true }
+bevy = { version = "0.9", default-features = false, features = ["bevy_winit", "bevy_render"], optional = true }
 

--- a/examples2d/Cargo.toml
+++ b/examples2d/Cargo.toml
@@ -2,7 +2,7 @@
 name    = "examples2d"
 version = "0.1.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
-edition = "2018"
+edition = "2021"
 
 [features]
 default = []
@@ -10,12 +10,12 @@ parallel = [ "rapier_testbed2d/parallel"]
 
 [dependencies]
 Inflector  = "0.11"
-nalgebra   = "0.29"
-parry2d = "0.6"
-rapier2d = "0.11"
-rapier_testbed2d = "0.11"
-parry3d = { version = "0.7" }
-bevy = "0.5"
+nalgebra   = "0.32.2"
+parry2d = "0.13.3"
+rapier2d = "0.17.2"
+rapier_testbed2d = "0.17"
+parry3d = { version = "0.13.3" }
+bevy = "0.9"
 
 [dependencies.salva2d]
 path = "../build/salva2d"

--- a/examples2d/basic2.rs
+++ b/examples2d/basic2.rs
@@ -1,8 +1,9 @@
 extern crate nalgebra as na;
 
 use na::{DVector, Point2, Point3, Vector2};
-use rapier2d::dynamics::{JointSet, RigidBodyBuilder, RigidBodySet};
+use rapier2d::dynamics::{ImpulseJointSet, RigidBodyBuilder, RigidBodySet};
 use rapier2d::geometry::{Collider, ColliderBuilder, ColliderSet};
+use rapier2d::prelude::{MultibodyJointSet, RigidBodyType};
 use rapier_testbed2d::Testbed;
 use salva2d::integrations::rapier::{ColliderSampling, FluidsPipeline, FluidsTestbedPlugin};
 use salva2d::object::{Boundary, Fluid};
@@ -20,7 +21,7 @@ pub fn init_world(testbed: &mut Testbed) {
     let mut plugin = FluidsTestbedPlugin::new();
     let mut bodies = RigidBodySet::new();
     let mut colliders = ColliderSet::new();
-    let joints = JointSet::new();
+    let joints = ImpulseJointSet::new();
     let mut fluids_pipeline = FluidsPipeline::new(PARTICLE_RADIUS, SMOOTHING_FACTOR);
 
     // Liquid.
@@ -85,7 +86,7 @@ pub fn init_world(testbed: &mut Testbed) {
         }
     });
 
-    let rigid_body = RigidBodyBuilder::new_static().build();
+    let rigid_body = RigidBodyBuilder::new(RigidBodyType::Fixed).build();
     let handle = bodies.insert(rigid_body);
     let collider = ColliderBuilder::heightfield(heights, ground_size).build();
     let co_handle = colliders.insert_with_parent(collider, handle, &mut bodies);
@@ -105,7 +106,7 @@ pub fn init_world(testbed: &mut Testbed) {
     let mut build_rigid_body_with_coupling = |x, y, collider: Collider| {
         let samples =
             salva2d::sampling::shape_surface_ray_sample(collider.shape(), PARTICLE_RADIUS).unwrap();
-        let rb = RigidBodyBuilder::new_dynamic()
+        let rb = RigidBodyBuilder::new(RigidBodyType::Dynamic)
             .translation(Vector2::new(x, y))
             .build();
         let _rb_handle = bodies.insert(rb);
@@ -132,7 +133,14 @@ pub fn init_world(testbed: &mut Testbed) {
      */
     plugin.set_pipeline(fluids_pipeline);
     testbed.add_plugin(plugin);
-    testbed.set_world_with_params(bodies, colliders, joints, gravity, ());
+    testbed.set_world_with_params(
+        bodies,
+        colliders,
+        joints,
+        MultibodyJointSet::new(),
+        gravity,
+        (),
+    );
     testbed.integration_parameters_mut().dt = 1.0 / 200.0;
     //    testbed.enable_boundary_particles_rendering(true);
 }

--- a/examples2d/custom_forces2.rs
+++ b/examples2d/custom_forces2.rs
@@ -1,7 +1,7 @@
 extern crate nalgebra as na;
 
 use na::{Point2, Point3, Unit, Vector2};
-use rapier2d::dynamics::{JointSet, RigidBodySet};
+use rapier2d::dynamics::{ImpulseJointSet, MultibodyJointSet, RigidBodySet};
 use rapier2d::geometry::ColliderSet;
 use rapier_testbed2d::Testbed;
 use salva2d::integrations::rapier::{FluidsPipeline, FluidsRenderingMode, FluidsTestbedPlugin};
@@ -23,7 +23,7 @@ pub fn init_world(testbed: &mut Testbed) {
     let mut plugin = FluidsTestbedPlugin::new();
     let bodies = RigidBodySet::new();
     let colliders = ColliderSet::new();
-    let joints = JointSet::new();
+    let joints = ImpulseJointSet::new();
     let mut fluids_pipeline = FluidsPipeline::new(PARTICLE_RADIUS, SMOOTHING_FACTOR);
 
     // Liquid.
@@ -46,7 +46,14 @@ pub fn init_world(testbed: &mut Testbed) {
     plugin.set_pipeline(fluids_pipeline);
     plugin.set_fluid_rendering_mode(FluidsRenderingMode::VelocityColor { min: 0.0, max: 5.0 });
     testbed.add_plugin(plugin);
-    testbed.set_world_with_params(bodies, colliders, joints, gravity, ());
+    testbed.set_world_with_params(
+        bodies,
+        colliders,
+        joints,
+        MultibodyJointSet::new(),
+        gravity,
+        (),
+    );
     testbed.integration_parameters_mut().dt = 1.0 / 200.0;
     testbed.look_at(Point2::origin(), 300.0);
 }

--- a/examples2d/elasticity2.rs
+++ b/examples2d/elasticity2.rs
@@ -1,8 +1,9 @@
 extern crate nalgebra as na;
 
 use na::{Isometry2, Point2, Point3, Vector2};
-use rapier2d::dynamics::{JointSet, RigidBodyBuilder, RigidBodySet};
+use rapier2d::dynamics::{ImpulseJointSet, RigidBodyBuilder, RigidBodySet};
 use rapier2d::geometry::{ColliderBuilder, ColliderSet};
+use rapier2d::prelude::{MultibodyJointSet, RigidBodyType};
 use rapier_testbed2d::Testbed;
 use salva2d::integrations::rapier::{
     ColliderSampling, FluidsPipeline, FluidsRenderingMode, FluidsTestbedPlugin,
@@ -25,7 +26,7 @@ pub fn init_world(testbed: &mut Testbed) {
     let mut plugin = FluidsTestbedPlugin::new();
     let mut bodies = RigidBodySet::new();
     let mut colliders = ColliderSet::new();
-    let joints = JointSet::new();
+    let joints = ImpulseJointSet::new();
     let mut fluids_pipeline = FluidsPipeline::new(PARTICLE_RADIUS, SMOOTHING_FACTOR);
 
     let ground_thickness = 0.2;
@@ -62,7 +63,7 @@ pub fn init_world(testbed: &mut Testbed) {
     plugin.set_fluid_color(fluid_handle, Point3::new(0.6, 0.8, 0.5));
 
     // Setup the ground.
-    bodies.insert(RigidBodyBuilder::new_static().build());
+    bodies.insert(RigidBodyBuilder::new(RigidBodyType::Fixed).build());
     let co = ColliderBuilder::cuboid(ground_half_width, ground_thickness).build();
     let co_handle = colliders.insert(co);
     let bo_handle = fluids_pipeline
@@ -80,7 +81,14 @@ pub fn init_world(testbed: &mut Testbed) {
     plugin.set_pipeline(fluids_pipeline);
     plugin.set_fluid_rendering_mode(FluidsRenderingMode::VelocityColor { min: 0.0, max: 5.0 });
     testbed.add_plugin(plugin);
-    testbed.set_world_with_params(bodies, colliders, joints, gravity, ());
+    testbed.set_world_with_params(
+        bodies,
+        colliders,
+        joints,
+        MultibodyJointSet::new(),
+        gravity,
+        (),
+    );
     testbed.integration_parameters_mut().dt = 1.0 / 200.0;
     testbed.look_at(Point2::new(0.0, 1.0), 100.0);
 }

--- a/examples2d/surface_tension2.rs
+++ b/examples2d/surface_tension2.rs
@@ -1,8 +1,9 @@
 extern crate nalgebra as na;
 
 use na::{Isometry2, Point2, Point3, Vector2};
-use rapier2d::dynamics::{JointSet, RigidBodyBuilder, RigidBodySet};
+use rapier2d::dynamics::{ImpulseJointSet, RigidBodyBuilder, RigidBodySet};
 use rapier2d::geometry::{ColliderBuilder, ColliderSet};
+use rapier2d::prelude::{MultibodyJointSet, RigidBodyType};
 use rapier_testbed2d::{Testbed, TestbedApp};
 use salva2d::integrations::rapier::{
     ColliderSampling, FluidsPipeline, FluidsRenderingMode, FluidsTestbedPlugin,
@@ -27,7 +28,7 @@ pub fn init_world(testbed: &mut Testbed) {
     let mut plugin = FluidsTestbedPlugin::new();
     let mut bodies = RigidBodySet::new();
     let mut colliders = ColliderSet::new();
-    let joints = JointSet::new();
+    let joints = ImpulseJointSet::new();
     let mut fluids_pipeline = FluidsPipeline::new(PARTICLE_RADIUS, SMOOTHING_FACTOR);
 
     // Initialize the fluid and give it some surface tension. This will make the fluid take a spherical shape.
@@ -44,7 +45,7 @@ pub fn init_world(testbed: &mut Testbed) {
     let ground_thickness = 0.02;
     let ground_half_width = 0.15;
 
-    bodies.insert(RigidBodyBuilder::new_static().build());
+    bodies.insert(RigidBodyBuilder::new(RigidBodyType::Fixed).build());
     let co = ColliderBuilder::cuboid(ground_half_width, ground_thickness).build();
     let co_handle = colliders.insert(co);
     let bo_handle = fluids_pipeline
@@ -62,7 +63,14 @@ pub fn init_world(testbed: &mut Testbed) {
     plugin.set_pipeline(fluids_pipeline);
     plugin.set_fluid_rendering_mode(FluidsRenderingMode::VelocityColor { min: 0.0, max: 5.0 });
     testbed.add_plugin(plugin);
-    testbed.set_world_with_params(bodies, colliders, joints, gravity, ());
+    testbed.set_world_with_params(
+        bodies,
+        colliders,
+        joints,
+        MultibodyJointSet::new(),
+        gravity,
+        (),
+    );
     testbed.integration_parameters_mut().dt = 1.0 / 200.0;
     testbed.look_at(Point2::origin(), 1500.0);
     //    testbed.enable_boundary_particles_rendering(true);

--- a/examples3d/Cargo.toml
+++ b/examples3d/Cargo.toml
@@ -2,7 +2,7 @@
 name    = "examples3d"
 version = "0.1.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
-edition = "2018"
+edition = "2021"
 
 [features]
 default = []
@@ -11,11 +11,11 @@ parallel = [ "rapier_testbed3d/parallel", "salva3d/parallel"]
 [dependencies]
 num-traits = "0.2"
 Inflector  = "0.11"
-nalgebra   = "0.29"
-rapier3d = "0.11"
-rapier_testbed3d = "0.11"
-parry3d = { version = "0.7" }
-bevy = "0.5"
+nalgebra = "0.32.2"
+rapier3d = "0.17.2"
+rapier_testbed3d = "0.17"
+parry3d = { version = "0.13.3" }
+bevy = "0.9"
 
 [dependencies.salva3d]
 path = "../build/salva3d"

--- a/examples3d/basic3.rs
+++ b/examples3d/basic3.rs
@@ -1,8 +1,9 @@
 extern crate nalgebra as na;
 
 use na::{Isometry3, Point3, Vector3};
-use rapier3d::dynamics::{JointSet, RigidBodyBuilder, RigidBodySet};
+use rapier3d::dynamics::{ImpulseJointSet, RigidBodyBuilder, RigidBodySet};
 use rapier3d::geometry::{ColliderBuilder, ColliderSet, SharedShape};
+use rapier3d::prelude::{MultibodyJointSet, RigidBodyType};
 use rapier_testbed3d::{Testbed, TestbedApp};
 use salva3d::integrations::rapier::{ColliderSampling, FluidsPipeline, FluidsTestbedPlugin};
 use salva3d::object::Boundary;
@@ -22,7 +23,7 @@ pub fn init_world(testbed: &mut Testbed) {
     let gravity = Vector3::y() * -9.81;
     let mut bodies = RigidBodySet::new();
     let mut colliders = ColliderSet::new();
-    let joints = JointSet::new();
+    let joints = ImpulseJointSet::new();
     let mut fluids_pipeline = FluidsPipeline::new(PARTICLE_RADIUS, SMOOTHING_FACTOR);
 
     // Parameters of the ground.
@@ -48,7 +49,7 @@ pub fn init_world(testbed: &mut Testbed) {
     let ground_shape = SharedShape::cuboid(ground_half_width, ground_thickness, ground_half_width);
     let wall_shape = SharedShape::cuboid(ground_thickness, ground_half_height, ground_half_width);
 
-    let ground_body = RigidBodyBuilder::new_static().build();
+    let ground_body = RigidBodyBuilder::new(RigidBodyType::Fixed).build();
     let ground_handle = bodies.insert(ground_body);
 
     let wall_poses = [
@@ -105,7 +106,14 @@ pub fn init_world(testbed: &mut Testbed) {
     plugin.render_boundary_particles = true;
     testbed.add_plugin(plugin);
     // testbed.set_body_wireframe(ground_handle, true);
-    testbed.set_world_with_params(bodies, colliders, joints, gravity, ());
+    testbed.set_world_with_params(
+        bodies,
+        colliders,
+        joints,
+        MultibodyJointSet::new(),
+        gravity,
+        (),
+    );
     testbed.integration_parameters_mut().dt = 1.0 / 200.0;
     testbed.look_at(Point3::new(3.0, 3.0, 3.0), Point3::origin());
 }

--- a/examples3d/custom_forces3.rs
+++ b/examples3d/custom_forces3.rs
@@ -1,8 +1,9 @@
 extern crate nalgebra as na;
 
 use na::{Point3, Unit, Vector3};
-use rapier3d::dynamics::{JointSet, RigidBodySet};
+use rapier3d::dynamics::{ImpulseJointSet, RigidBodySet};
 use rapier3d::geometry::ColliderSet;
+use rapier3d::prelude::MultibodyJointSet;
 use rapier_testbed3d::{Testbed, TestbedApp};
 use salva3d::integrations::rapier::{FluidsPipeline, FluidsRenderingMode, FluidsTestbedPlugin};
 use salva3d::object::{Boundary, Fluid};
@@ -23,7 +24,7 @@ pub fn init_world(testbed: &mut Testbed) {
     let mut plugin = FluidsTestbedPlugin::new();
     let bodies = RigidBodySet::new();
     let colliders = ColliderSet::new();
-    let joints = JointSet::new();
+    let joints = ImpulseJointSet::new();
     let mut fluids_pipeline = FluidsPipeline::new(PARTICLE_RADIUS, SMOOTHING_FACTOR);
 
     // fluids.
@@ -46,7 +47,14 @@ pub fn init_world(testbed: &mut Testbed) {
     plugin.set_pipeline(fluids_pipeline);
     plugin.set_fluid_rendering_mode(FluidsRenderingMode::VelocityColor { min: 0.0, max: 5.0 });
     testbed.add_plugin(plugin);
-    testbed.set_world_with_params(bodies, colliders, joints, gravity, ());
+    testbed.set_world_with_params(
+        bodies,
+        colliders,
+        joints,
+        MultibodyJointSet::new(),
+        gravity,
+        (),
+    );
     testbed.integration_parameters_mut().dt = 1.0 / 200.0;
     testbed.look_at(Point3::new(3.0, 3.0, 3.0), Point3::origin());
 }

--- a/examples3d/elasticity3.rs
+++ b/examples3d/elasticity3.rs
@@ -1,8 +1,9 @@
 extern crate nalgebra as na;
 
 use na::{Isometry3, Point3, Vector3};
-use rapier3d::dynamics::{JointSet, RigidBodyBuilder, RigidBodySet};
+use rapier3d::dynamics::{ImpulseJointSet, RigidBodyBuilder, RigidBodySet};
 use rapier3d::geometry::{ColliderBuilder, ColliderSet};
+use rapier3d::prelude::{MultibodyJointSet, RigidBodyType};
 use rapier_testbed3d::{Testbed, TestbedApp};
 use salva3d::integrations::rapier::{
     ColliderSampling, FluidsPipeline, FluidsRenderingMode, FluidsTestbedPlugin,
@@ -25,7 +26,7 @@ pub fn init_world(testbed: &mut Testbed) {
     let mut plugin = FluidsTestbedPlugin::new();
     let mut bodies = RigidBodySet::new();
     let mut colliders = ColliderSet::new();
-    let joints = JointSet::new();
+    let joints = ImpulseJointSet::new();
     let mut fluids_pipeline = FluidsPipeline::new(PARTICLE_RADIUS, SMOOTHING_FACTOR);
 
     // Parameters of the ground.
@@ -76,7 +77,7 @@ pub fn init_world(testbed: &mut Testbed) {
     plugin.set_fluid_color(fluid_handle, Point3::new(0.6, 0.8, 0.5));
 
     // Setup the ground.
-    let ground_handle = bodies.insert(RigidBodyBuilder::new_static().build());
+    let ground_handle = bodies.insert(RigidBodyBuilder::new(RigidBodyType::Fixed).build());
     let co =
         ColliderBuilder::cuboid(ground_half_width, ground_thickness, ground_half_width).build();
     let co_handle = colliders.insert(co);
@@ -96,7 +97,14 @@ pub fn init_world(testbed: &mut Testbed) {
     plugin.set_fluid_rendering_mode(FluidsRenderingMode::VelocityColor { min: 0.0, max: 5.0 });
     testbed.add_plugin(plugin);
     testbed.set_body_wireframe(ground_handle, true);
-    testbed.set_world_with_params(bodies, colliders, joints, gravity, ());
+    testbed.set_world_with_params(
+        bodies,
+        colliders,
+        joints,
+        MultibodyJointSet::new(),
+        gravity,
+        (),
+    );
     testbed.integration_parameters_mut().dt = 1.0 / 200.0;
     testbed.look_at(Point3::new(1.5, 1.5, 1.5), Point3::origin());
 }

--- a/examples3d/faucet3.rs
+++ b/examples3d/faucet3.rs
@@ -1,8 +1,9 @@
 extern crate nalgebra as na;
 
 use na::{Point3, Vector3};
-use rapier3d::dynamics::{JointSet, RigidBodyBuilder, RigidBodySet};
+use rapier3d::dynamics::{ImpulseJointSet, RigidBodyBuilder, RigidBodySet};
 use rapier3d::geometry::{ColliderBuilder, ColliderSet};
+use rapier3d::prelude::{MultibodyJointSet, RigidBodyType};
 use rapier_testbed3d::{Testbed, TestbedApp};
 use salva3d::integrations::rapier::{ColliderSampling, FluidsPipeline, FluidsTestbedPlugin};
 use salva3d::object::{Boundary, Fluid};
@@ -23,7 +24,7 @@ pub fn init_world(testbed: &mut Testbed) {
     let gravity = Vector3::y() * -9.81;
     let mut bodies = RigidBodySet::new();
     let mut colliders = ColliderSet::new();
-    let joints = JointSet::new();
+    let joints = ImpulseJointSet::new();
     let mut fluids_pipeline = FluidsPipeline::new(PARTICLE_RADIUS, SMOOTHING_FACTOR);
 
     let ground_rad = 0.15;
@@ -38,7 +39,7 @@ pub fn init_world(testbed: &mut Testbed) {
     plugin.set_fluid_color(fluid_handle, Point3::new(0.5, 1.0, 1.0));
 
     // Setup the ground.
-    let ground_handle = bodies.insert(RigidBodyBuilder::new_static().build());
+    let ground_handle = bodies.insert(RigidBodyBuilder::new(RigidBodyType::Fixed).build());
     let co = ColliderBuilder::ball(ground_rad).build();
     let ball_samples =
         salva3d::sampling::shape_surface_ray_sample(co.shape(), PARTICLE_RADIUS).unwrap();
@@ -100,7 +101,14 @@ pub fn init_world(testbed: &mut Testbed) {
     plugin.set_pipeline(fluids_pipeline);
     testbed.add_plugin(plugin);
     testbed.set_body_wireframe(ground_handle, true);
-    testbed.set_world_with_params(bodies, colliders, joints, gravity, ());
+    testbed.set_world_with_params(
+        bodies,
+        colliders,
+        joints,
+        MultibodyJointSet::new(),
+        gravity,
+        (),
+    );
     testbed.integration_parameters_mut().dt = 1.0 / 200.0;
     // testbed.enable_boundary_particles_rendering(true);
     testbed.look_at(Point3::new(1.5, 0.0, 1.5), Point3::new(0.0, 0.0, 0.0));

--- a/examples3d/harness_basic3.rs
+++ b/examples3d/harness_basic3.rs
@@ -1,8 +1,9 @@
 extern crate nalgebra as na;
 
 use na::{Isometry3, Vector3};
-use rapier3d::dynamics::{JointSet, RigidBodyBuilder, RigidBodySet};
+use rapier3d::dynamics::{ImpulseJointSet, RigidBodyBuilder, RigidBodySet};
 use rapier3d::geometry::{ColliderBuilder, ColliderSet, SharedShape};
+use rapier3d::prelude::{MultibodyJointSet, RigidBodyType};
 use rapier_testbed3d::harness::Harness;
 use salva3d::integrations::rapier::{ColliderSampling, FluidsHarnessPlugin, FluidsPipeline};
 use salva3d::object::Boundary;
@@ -23,7 +24,7 @@ pub fn init_world(harness: &mut Harness) {
     let gravity = Vector3::y() * -9.81;
     let mut bodies = RigidBodySet::new();
     let mut colliders = ColliderSet::new();
-    let joints = JointSet::new();
+    let joints = ImpulseJointSet::new();
     let mut fluids_pipeline = FluidsPipeline::new(PARTICLE_RADIUS, SMOOTHING_FACTOR);
 
     // Parameters of the ground.
@@ -49,7 +50,7 @@ pub fn init_world(harness: &mut Harness) {
     let ground_shape = SharedShape::cuboid(ground_half_width, ground_thickness, ground_half_width);
     let wall_shape = SharedShape::cuboid(ground_thickness, ground_half_height, ground_half_width);
 
-    let ground_body = RigidBodyBuilder::new_static().build();
+    let ground_body = RigidBodyBuilder::new(RigidBodyType::Fixed).build();
     let ground_handle = bodies.insert(ground_body);
 
     let wall_poses = [
@@ -103,7 +104,14 @@ pub fn init_world(harness: &mut Harness) {
     let mut plugin = FluidsHarnessPlugin::new();
     plugin.set_pipeline(fluids_pipeline);
     harness.add_plugin(plugin);
-    harness.set_world_with_params(bodies, colliders, joints, gravity, ());
+    harness.set_world_with_params(
+        bodies,
+        colliders,
+        joints,
+        MultibodyJointSet::new(),
+        gravity,
+        (),
+    );
     harness.integration_parameters_mut().dt = 1.0 / 200.0;
 }
 

--- a/examples3d/heightfield3.rs
+++ b/examples3d/heightfield3.rs
@@ -22,7 +22,7 @@ pub fn init_world(testbed: &mut Testbed) {
      */
     let mut bodies = RigidBodySet::new();
     let mut colliders = ColliderSet::new();
-    let joints = JointSet::new();
+    let joints = ImpulseJointSet::new();
 
     /* Fluid */
     let mut fluids_pipeline = FluidsPipeline::new(PARTICLE_RADIUS, SMOOTHING_FACTOR);
@@ -59,7 +59,7 @@ pub fn init_world(testbed: &mut Testbed) {
         }
     });
 
-    let rigid_body = RigidBodyBuilder::new_static().build();
+    let rigid_body = RigidBodyBuilder::new(RigidBodyType::Fixed).build();
     let handle = bodies.insert(rigid_body);
     let ground_collider = ColliderBuilder::heightfield(heights.clone(), ground_size).build();
     let ground_handle = colliders.insert_with_parent(ground_collider.clone(), handle, &mut bodies);
@@ -89,6 +89,6 @@ pub fn init_world(testbed: &mut Testbed) {
     /*
      * Set up the testbed.
      */
-    testbed.set_world(bodies, colliders, joints);
+    testbed.set_world(bodies, colliders, joints, MultibodyJointSet::new());
     testbed.look_at(point![100.0, 100.0, 100.0], Point::origin());
 }

--- a/examples3d/surface_tension3.rs
+++ b/examples3d/surface_tension3.rs
@@ -1,8 +1,9 @@
 extern crate nalgebra as na;
 
 use na::{Isometry3, Point3, Vector3};
-use rapier3d::dynamics::{JointSet, RigidBodyBuilder, RigidBodySet};
+use rapier3d::dynamics::{ImpulseJointSet, RigidBodyBuilder, RigidBodySet};
 use rapier3d::geometry::{ColliderBuilder, ColliderSet};
+use rapier3d::prelude::{MultibodyJointSet, RigidBodyType};
 use rapier_testbed3d::{Testbed, TestbedApp};
 use salva3d::integrations::rapier::{
     ColliderSampling, FluidsPipeline, FluidsRenderingMode, FluidsTestbedPlugin,
@@ -27,7 +28,7 @@ pub fn init_world(testbed: &mut Testbed) {
     let mut plugin = FluidsTestbedPlugin::new();
     let mut bodies = RigidBodySet::new();
     let mut colliders = ColliderSet::new();
-    let joints = JointSet::new();
+    let joints = ImpulseJointSet::new();
     let mut fluids_pipeline = FluidsPipeline::new(PARTICLE_RADIUS, SMOOTHING_FACTOR);
 
     /*
@@ -44,7 +45,7 @@ pub fn init_world(testbed: &mut Testbed) {
     plugin.set_fluid_color(fluid_handle, Point3::new(0.8, 0.7, 1.0));
 
     // Setup the ground.
-    let ground_handle = bodies.insert(RigidBodyBuilder::new_static().build());
+    let ground_handle = bodies.insert(RigidBodyBuilder::new(RigidBodyType::Fixed).build());
 
     let ground_thickness = 0.02;
     let ground_half_width = 0.15;
@@ -69,7 +70,14 @@ pub fn init_world(testbed: &mut Testbed) {
     plugin.set_fluid_rendering_mode(FluidsRenderingMode::VelocityColor { min: 0.0, max: 5.0 });
     testbed.add_plugin(plugin);
     testbed.set_body_wireframe(ground_handle, true);
-    testbed.set_world_with_params(bodies, colliders, joints, gravity, ());
+    testbed.set_world_with_params(
+        bodies,
+        colliders,
+        joints,
+        MultibodyJointSet::new(),
+        gravity,
+        (),
+    );
     testbed.integration_parameters_mut().dt = 1.0 / 200.0;
     testbed.look_at(Point3::new(0.25, 0.25, 0.25), Point3::origin());
 }

--- a/src/integrations/rapier/fluids_pipeline.rs
+++ b/src/integrations/rapier/fluids_pipeline.rs
@@ -277,7 +277,7 @@ impl<'a> CouplingManager for ColliderCouplingManager<'a> {
                             for (pos, force) in
                                 boundary.positions.iter().zip(forces.iter().cloned())
                             {
-                                body.apply_force_at_point(force, *pos, true)
+                                body.apply_impulse_at_point(force, *pos, true)
                             }
                         }
                     }

--- a/src/liquid_world.rs
+++ b/src/liquid_world.rs
@@ -10,7 +10,7 @@ use crate::TimestepManager;
 use {
     crate::math::Isometry,
     crate::object::ParticleId,
-    parry::{bounding_volume::AABB, query::PointQuery, shape::Shape},
+    parry::{bounding_volume::Aabb, query::PointQuery, shape::Shape},
 };
 
 /// The physics world for simulating fluids with boundaries.
@@ -211,7 +211,7 @@ impl LiquidWorld {
     #[cfg(feature = "parry")]
     pub fn particles_intersecting_aabb<'a>(
         &'a self,
-        aabb: AABB,
+        aabb: Aabb,
     ) -> impl Iterator<Item = ParticleId> + 'a {
         self.hgrid
             .cells_intersecting_aabb(&aabb.mins, &aabb.maxs)

--- a/src/sampling/ray_sampling.rs
+++ b/src/sampling/ray_sampling.rs
@@ -1,6 +1,6 @@
 use crate::math::{Isometry, Point, Real, Vector, DIM};
 
-use parry::bounding_volume::{BoundingVolume, AABB};
+use parry::bounding_volume::{Aabb, BoundingVolume};
 use parry::query::{Ray, RayCast};
 use rapier::geometry::Shape;
 use std::collections::HashSet;
@@ -26,7 +26,7 @@ pub fn shape_volume_ray_sample<S: ?Sized + Shape>(
 /// Samples the surface of `shape` with a method based on ray-casting.
 pub fn surface_ray_sample<S: ?Sized + RayCast>(
     shape: &S,
-    volume: &AABB,
+    volume: &Aabb,
     particle_rad: Real,
 ) -> Vec<Point<Real>> {
     let mut quantized_points = HashSet::new();
@@ -90,7 +90,7 @@ pub fn surface_ray_sample<S: ?Sized + RayCast>(
 /// Samples the volume of `shape` with a method based on ray-casting.
 pub fn volume_ray_sample<S: ?Sized + RayCast>(
     shape: &S,
-    volume: &AABB,
+    volume: &Aabb,
     particle_rad: Real,
 ) -> Vec<Point<Real>> {
     let mut quantized_points = HashSet::new();


### PR DESCRIPTION
The examples do not run on my Apple M1, due to the out of date bevy.

I updated to bevy .9 not .10 as other dependencies are on .9 currently.
Resolver = "2" is needed for the newer WGPU used.


Example 2d:

![image](https://user-images.githubusercontent.com/6392201/229385910-6fd0a222-5b4a-4a45-a266-e0ddb21e0546.png)

Example 3d:

![image](https://user-images.githubusercontent.com/6392201/229385962-c1b44c71-933a-4270-821c-cd134c0971ed.png)

