### PR TITLE
Update bevy, rapier, parry, nalgebra

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [ "build/salva2d", "build/salva3d", "examples2d", "examples3d" ]
+resolver = "2"
 
 [profile.release]
 #lto = true
@@ -17,10 +18,10 @@ salva3d = { path = "./build/salva3d" }
 #rapier_testbed2d = { git = "https://github.com/dimforge/rapier", branch = "split_geom"  }
 #rapier_testbed3d = { git = "https://github.com/dimforge/rapier", branch = "split_geom"  }
 
-#rapier2d = { git = "https://github.com/dimforge/rapier"}
-#rapier3d = { git = "https://github.com/dimforge/rapier"}
-#rapier_testbed2d = { git = "https://github.com/dimforge/rapier" }
-#rapier_testbed3d = { git = "https://github.com/dimforge/rapier" }
+rapier2d = { git = "https://github.com/dimforge/rapier" }
+rapier3d = { git = "https://github.com/dimforge/rapier" }
+rapier_testbed2d = { git = "https://github.com/dimforge/rapier" }
+rapier_testbed3d = { git = "https://github.com/dimforge/rapier" }
 
 # rapier2d = { git = "https://github.com/dimforge/rapier", rev = "3b0d256" }
 # rapier3d = { git = "https://github.com/dimforge/rapier", rev = "3b0d256" }

--- a/build/salva2d/Cargo.toml
+++ b/build/salva2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "salva2d"
-version = "0.7.0"
+version = "0.8.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "2-dimensional particle-based fluid dynamics in Rust."
 documentation = "https://salva.rs/docs"
@@ -10,7 +10,7 @@ readme = "README.md"
 categories = [ "science", "game-development", "mathematics", "simulation", "wasm"]
 keywords = [ "physics", "dynamics", "particles", "fluids", "SPH" ]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [badges]
 maintenance = { status = "actively-developed" }
@@ -33,25 +33,24 @@ path = "../../src/lib.rs"
 required-features = [ "dim2" ]
 
 [dependencies]
-approx = "0.4"
+approx = "0.5"
 num-traits = "0.2"
 fnv = "1.0"
-itertools = "0.10"
+itertools = "0.12"
 generational-arena = "0.2"
 instant = { version = "0.1", features = [ "now" ] }
-rayon = { version = "1.5", optional = true }
+rayon = { version = "1.8", optional = true }
 
-nalgebra  = "0.29"
-parry2d = { version = "0.7", optional = true }
-rapier2d = { version = "0.11", optional = true }
-rapier_testbed2d = { version = "0.11", optional = true }
+nalgebra  = "0.32"
+parry2d = { version = "0.13", optional = true }
+rapier2d = { version = "0.17", optional = true }
+rapier_testbed2d = { version = "0.17", optional = true }
 
-bevy_egui = { version = "0.5", optional = true }
+bevy_egui = { version = "0.23", features = ["immutable_ctx"], optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-bevy = { version = "0.5", default-features = false, features = ["bevy_wgpu", "bevy_winit", "render", "x11"], optional = true }
+bevy = { version = "0.12.1", default-features = false, features = ["bevy_winit", "bevy_render", "x11"], optional = true }
 
 # Dependencies for WASM only.
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-bevy = { version = "0.5", default-features = false, features = ["bevy_winit", "render"], optional = true }
-bevy_webgl2 = { version = "0.5", optional = true }
+bevy = { version = "0.12", default-features = false, features = ["bevy_winit", "bevy_render"], optional = true }

--- a/build/salva3d/Cargo.toml
+++ b/build/salva3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "salva3d"
-version = "0.7.0"
+version = "0.8.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "3-dimensional particle-based fluid dynamics in Rust."
 documentation = "https://salva.rs/rustdoc/salva3d/index.html"
@@ -9,7 +9,7 @@ repository = "https://github.com/dimforge/salva"
 readme = "README.md"
 keywords = [ "physics", "dynamics", "particles", "fluids", "SPH" ]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [features]
 default = [ "dim3" ]
@@ -29,26 +29,24 @@ path = "../../src/lib.rs"
 required-features = [ "dim3" ]
 
 [dependencies]
-approx = "0.4"
+approx = "0.5"
 num-traits = "0.2"
 fnv = "1.0"
-itertools = "0.10"
+itertools = "0.12"
 generational-arena = "0.2"
 instant = { version = "0.1", features = [ "now" ] }
-rayon = { version = "1.5", optional = true }
+rayon = { version = "1.8", optional = true }
 
-nalgebra  = "0.29"
-parry3d = { version = "0.7", optional = true }
-rapier3d = { version = "0.11", optional = true }
-rapier_testbed3d = { version = "0.11", optional = true }
+nalgebra  = "0.32"
+parry3d = { version = "0.13", optional = true }
+rapier3d = { version = "0.17", optional = true }
+rapier_testbed3d = { version = "0.17", optional = true }
 
-bevy_egui = { version = "0.5", optional = true }
+bevy_egui = { version = "0.23", features = ["immutable_ctx"], optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-bevy = { version = "0.5", default-features = false, features = ["bevy_wgpu", "bevy_winit", "render", "x11"], optional = true }
+bevy = { version = "0.12", default-features = false, features = ["bevy_winit", "bevy_render", "x11"], optional = true }
 
 # Dependencies for WASM only.
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-bevy = { version = "0.5", default-features = false, features = ["bevy_winit", "render"], optional = true }
-bevy_webgl2 = { version = "0.5", optional = true }
-
+bevy = { version = "0.12", default-features = false, features = ["bevy_winit", "bevy_render"], optional = true }

--- a/examples2d/Cargo.toml
+++ b/examples2d/Cargo.toml
@@ -10,12 +10,12 @@ parallel = [ "rapier_testbed2d/parallel"]
 
 [dependencies]
 Inflector  = "0.11"
-nalgebra   = "0.29"
-parry2d = "0.6"
-rapier2d = "0.11"
-rapier_testbed2d = "0.11"
-parry3d = { version = "0.7" }
-bevy = "0.5"
+nalgebra   = "0.32"
+parry2d = "0.13"
+rapier2d = "0.17"
+rapier_testbed2d = "0.17"
+parry3d = "0.13"
+bevy = "0.12.1"
 
 [dependencies.salva2d]
 path = "../build/salva2d"

--- a/examples2d/custom_forces2.rs
+++ b/examples2d/custom_forces2.rs
@@ -1,7 +1,7 @@
 extern crate nalgebra as na;
 
 use na::{Point2, Point3, Unit, Vector2};
-use rapier2d::dynamics::{JointSet, RigidBodySet};
+use rapier2d::dynamics::{ImpulseJointSet, MultibodyJointSet, RigidBodySet};
 use rapier2d::geometry::ColliderSet;
 use rapier_testbed2d::Testbed;
 use salva2d::integrations::rapier::{FluidsPipeline, FluidsRenderingMode, FluidsTestbedPlugin};
@@ -23,7 +23,8 @@ pub fn init_world(testbed: &mut Testbed) {
     let mut plugin = FluidsTestbedPlugin::new();
     let bodies = RigidBodySet::new();
     let colliders = ColliderSet::new();
-    let joints = JointSet::new();
+    let impulse_joints = ImpulseJointSet::new();
+    let multibody_joints = MultibodyJointSet::new();
     let mut fluids_pipeline = FluidsPipeline::new(PARTICLE_RADIUS, SMOOTHING_FACTOR);
 
     // Liquid.
@@ -46,7 +47,14 @@ pub fn init_world(testbed: &mut Testbed) {
     plugin.set_pipeline(fluids_pipeline);
     plugin.set_fluid_rendering_mode(FluidsRenderingMode::VelocityColor { min: 0.0, max: 5.0 });
     testbed.add_plugin(plugin);
-    testbed.set_world_with_params(bodies, colliders, joints, gravity, ());
+    testbed.set_world_with_params(
+        bodies,
+        colliders,
+        impulse_joints,
+        multibody_joints,
+        gravity,
+        (),
+    );
     testbed.integration_parameters_mut().dt = 1.0 / 200.0;
     testbed.look_at(Point2::origin(), 300.0);
 }

--- a/examples2d/elasticity2.rs
+++ b/examples2d/elasticity2.rs
@@ -1,7 +1,7 @@
 extern crate nalgebra as na;
 
 use na::{Isometry2, Point2, Point3, Vector2};
-use rapier2d::dynamics::{JointSet, RigidBodyBuilder, RigidBodySet};
+use rapier2d::dynamics::{ImpulseJointSet, MultibodyJointSet, RigidBodyBuilder, RigidBodySet};
 use rapier2d::geometry::{ColliderBuilder, ColliderSet};
 use rapier_testbed2d::Testbed;
 use salva2d::integrations::rapier::{
@@ -25,7 +25,8 @@ pub fn init_world(testbed: &mut Testbed) {
     let mut plugin = FluidsTestbedPlugin::new();
     let mut bodies = RigidBodySet::new();
     let mut colliders = ColliderSet::new();
-    let joints = JointSet::new();
+    let impulse_joints = ImpulseJointSet::new();
+    let multibody_joints = MultibodyJointSet::new();
     let mut fluids_pipeline = FluidsPipeline::new(PARTICLE_RADIUS, SMOOTHING_FACTOR);
 
     let ground_thickness = 0.2;
@@ -62,7 +63,7 @@ pub fn init_world(testbed: &mut Testbed) {
     plugin.set_fluid_color(fluid_handle, Point3::new(0.6, 0.8, 0.5));
 
     // Setup the ground.
-    bodies.insert(RigidBodyBuilder::new_static().build());
+    bodies.insert(RigidBodyBuilder::fixed().build());
     let co = ColliderBuilder::cuboid(ground_half_width, ground_thickness).build();
     let co_handle = colliders.insert(co);
     let bo_handle = fluids_pipeline
@@ -80,7 +81,14 @@ pub fn init_world(testbed: &mut Testbed) {
     plugin.set_pipeline(fluids_pipeline);
     plugin.set_fluid_rendering_mode(FluidsRenderingMode::VelocityColor { min: 0.0, max: 5.0 });
     testbed.add_plugin(plugin);
-    testbed.set_world_with_params(bodies, colliders, joints, gravity, ());
+    testbed.set_world_with_params(
+        bodies,
+        colliders,
+        impulse_joints,
+        multibody_joints,
+        gravity,
+        (),
+    );
     testbed.integration_parameters_mut().dt = 1.0 / 200.0;
     testbed.look_at(Point2::new(0.0, 1.0), 100.0);
 }

--- a/examples2d/surface_tension2.rs
+++ b/examples2d/surface_tension2.rs
@@ -1,7 +1,7 @@
 extern crate nalgebra as na;
 
 use na::{Isometry2, Point2, Point3, Vector2};
-use rapier2d::dynamics::{JointSet, RigidBodyBuilder, RigidBodySet};
+use rapier2d::dynamics::{ImpulseJointSet, MultibodyJointSet, RigidBodyBuilder, RigidBodySet};
 use rapier2d::geometry::{ColliderBuilder, ColliderSet};
 use rapier_testbed2d::{Testbed, TestbedApp};
 use salva2d::integrations::rapier::{
@@ -27,7 +27,8 @@ pub fn init_world(testbed: &mut Testbed) {
     let mut plugin = FluidsTestbedPlugin::new();
     let mut bodies = RigidBodySet::new();
     let mut colliders = ColliderSet::new();
-    let joints = JointSet::new();
+    let impulse_joints = ImpulseJointSet::new();
+    let multibody_joints = MultibodyJointSet::new();
     let mut fluids_pipeline = FluidsPipeline::new(PARTICLE_RADIUS, SMOOTHING_FACTOR);
 
     // Initialize the fluid and give it some surface tension. This will make the fluid take a spherical shape.
@@ -44,7 +45,7 @@ pub fn init_world(testbed: &mut Testbed) {
     let ground_thickness = 0.02;
     let ground_half_width = 0.15;
 
-    bodies.insert(RigidBodyBuilder::new_static().build());
+    bodies.insert(RigidBodyBuilder::fixed().build());
     let co = ColliderBuilder::cuboid(ground_half_width, ground_thickness).build();
     let co_handle = colliders.insert(co);
     let bo_handle = fluids_pipeline
@@ -62,7 +63,14 @@ pub fn init_world(testbed: &mut Testbed) {
     plugin.set_pipeline(fluids_pipeline);
     plugin.set_fluid_rendering_mode(FluidsRenderingMode::VelocityColor { min: 0.0, max: 5.0 });
     testbed.add_plugin(plugin);
-    testbed.set_world_with_params(bodies, colliders, joints, gravity, ());
+    testbed.set_world_with_params(
+        bodies,
+        colliders,
+        impulse_joints,
+        multibody_joints,
+        gravity,
+        (),
+    );
     testbed.integration_parameters_mut().dt = 1.0 / 200.0;
     testbed.look_at(Point2::origin(), 1500.0);
     //    testbed.enable_boundary_particles_rendering(true);

--- a/examples3d/Cargo.toml
+++ b/examples3d/Cargo.toml
@@ -11,11 +11,11 @@ parallel = [ "rapier_testbed3d/parallel", "salva3d/parallel"]
 [dependencies]
 num-traits = "0.2"
 Inflector  = "0.11"
-nalgebra   = "0.29"
-rapier3d = "0.11"
-rapier_testbed3d = "0.11"
-parry3d = { version = "0.7" }
-bevy = "0.5"
+nalgebra   = "0.32"
+rapier3d = "0.17"
+rapier_testbed3d = "0.17"
+parry3d = "0.13"
+bevy = "0.12.1"
 
 [dependencies.salva3d]
 path = "../build/salva3d"

--- a/examples3d/basic3.rs
+++ b/examples3d/basic3.rs
@@ -1,7 +1,7 @@
 extern crate nalgebra as na;
 
 use na::{Isometry3, Point3, Vector3};
-use rapier3d::dynamics::{JointSet, RigidBodyBuilder, RigidBodySet};
+use rapier3d::dynamics::{ImpulseJointSet, MultibodyJointSet, RigidBodyBuilder, RigidBodySet};
 use rapier3d::geometry::{ColliderBuilder, ColliderSet, SharedShape};
 use rapier_testbed3d::{Testbed, TestbedApp};
 use salva3d::integrations::rapier::{ColliderSampling, FluidsPipeline, FluidsTestbedPlugin};
@@ -22,7 +22,8 @@ pub fn init_world(testbed: &mut Testbed) {
     let gravity = Vector3::y() * -9.81;
     let mut bodies = RigidBodySet::new();
     let mut colliders = ColliderSet::new();
-    let joints = JointSet::new();
+    let impulse_joints = ImpulseJointSet::new();
+    let multibody_joints = MultibodyJointSet::new();
     let mut fluids_pipeline = FluidsPipeline::new(PARTICLE_RADIUS, SMOOTHING_FACTOR);
 
     // Parameters of the ground.
@@ -48,7 +49,7 @@ pub fn init_world(testbed: &mut Testbed) {
     let ground_shape = SharedShape::cuboid(ground_half_width, ground_thickness, ground_half_width);
     let wall_shape = SharedShape::cuboid(ground_thickness, ground_half_height, ground_half_width);
 
-    let ground_body = RigidBodyBuilder::new_static().build();
+    let ground_body = RigidBodyBuilder::fixed().build();
     let ground_handle = bodies.insert(ground_body);
 
     let wall_poses = [
@@ -105,7 +106,14 @@ pub fn init_world(testbed: &mut Testbed) {
     plugin.render_boundary_particles = true;
     testbed.add_plugin(plugin);
     // testbed.set_body_wireframe(ground_handle, true);
-    testbed.set_world_with_params(bodies, colliders, joints, gravity, ());
+    testbed.set_world_with_params(
+        bodies,
+        colliders,
+        impulse_joints,
+        multibody_joints,
+        gravity,
+        (),
+    );
     testbed.integration_parameters_mut().dt = 1.0 / 200.0;
     testbed.look_at(Point3::new(3.0, 3.0, 3.0), Point3::origin());
 }

--- a/examples3d/custom_forces3.rs
+++ b/examples3d/custom_forces3.rs
@@ -1,7 +1,7 @@
 extern crate nalgebra as na;
 
 use na::{Point3, Unit, Vector3};
-use rapier3d::dynamics::{JointSet, RigidBodySet};
+use rapier3d::dynamics::{ImpulseJointSet, MultibodyJointSet, RigidBodySet};
 use rapier3d::geometry::ColliderSet;
 use rapier_testbed3d::{Testbed, TestbedApp};
 use salva3d::integrations::rapier::{FluidsPipeline, FluidsRenderingMode, FluidsTestbedPlugin};
@@ -23,7 +23,8 @@ pub fn init_world(testbed: &mut Testbed) {
     let mut plugin = FluidsTestbedPlugin::new();
     let bodies = RigidBodySet::new();
     let colliders = ColliderSet::new();
-    let joints = JointSet::new();
+    let impulse_joints = ImpulseJointSet::new();
+    let multibody_joints = MultibodyJointSet::new();
     let mut fluids_pipeline = FluidsPipeline::new(PARTICLE_RADIUS, SMOOTHING_FACTOR);
 
     // fluids.
@@ -46,7 +47,14 @@ pub fn init_world(testbed: &mut Testbed) {
     plugin.set_pipeline(fluids_pipeline);
     plugin.set_fluid_rendering_mode(FluidsRenderingMode::VelocityColor { min: 0.0, max: 5.0 });
     testbed.add_plugin(plugin);
-    testbed.set_world_with_params(bodies, colliders, joints, gravity, ());
+    testbed.set_world_with_params(
+        bodies,
+        colliders,
+        impulse_joints,
+        multibody_joints,
+        gravity,
+        (),
+    );
     testbed.integration_parameters_mut().dt = 1.0 / 200.0;
     testbed.look_at(Point3::new(3.0, 3.0, 3.0), Point3::origin());
 }

--- a/examples3d/elasticity3.rs
+++ b/examples3d/elasticity3.rs
@@ -1,7 +1,7 @@
 extern crate nalgebra as na;
 
 use na::{Isometry3, Point3, Vector3};
-use rapier3d::dynamics::{JointSet, RigidBodyBuilder, RigidBodySet};
+use rapier3d::dynamics::{ImpulseJointSet, MultibodyJointSet, RigidBodyBuilder, RigidBodySet};
 use rapier3d::geometry::{ColliderBuilder, ColliderSet};
 use rapier_testbed3d::{Testbed, TestbedApp};
 use salva3d::integrations::rapier::{
@@ -25,7 +25,8 @@ pub fn init_world(testbed: &mut Testbed) {
     let mut plugin = FluidsTestbedPlugin::new();
     let mut bodies = RigidBodySet::new();
     let mut colliders = ColliderSet::new();
-    let joints = JointSet::new();
+    let impulse_joints = ImpulseJointSet::new();
+    let multibody_joints = MultibodyJointSet::new();
     let mut fluids_pipeline = FluidsPipeline::new(PARTICLE_RADIUS, SMOOTHING_FACTOR);
 
     // Parameters of the ground.
@@ -76,7 +77,7 @@ pub fn init_world(testbed: &mut Testbed) {
     plugin.set_fluid_color(fluid_handle, Point3::new(0.6, 0.8, 0.5));
 
     // Setup the ground.
-    let ground_handle = bodies.insert(RigidBodyBuilder::new_static().build());
+    let ground_handle = bodies.insert(RigidBodyBuilder::fixed().build());
     let co =
         ColliderBuilder::cuboid(ground_half_width, ground_thickness, ground_half_width).build();
     let co_handle = colliders.insert(co);
@@ -96,7 +97,14 @@ pub fn init_world(testbed: &mut Testbed) {
     plugin.set_fluid_rendering_mode(FluidsRenderingMode::VelocityColor { min: 0.0, max: 5.0 });
     testbed.add_plugin(plugin);
     testbed.set_body_wireframe(ground_handle, true);
-    testbed.set_world_with_params(bodies, colliders, joints, gravity, ());
+    testbed.set_world_with_params(
+        bodies,
+        colliders,
+        impulse_joints,
+        multibody_joints,
+        gravity,
+        (),
+    );
     testbed.integration_parameters_mut().dt = 1.0 / 200.0;
     testbed.look_at(Point3::new(1.5, 1.5, 1.5), Point3::origin());
 }

--- a/examples3d/faucet3.rs
+++ b/examples3d/faucet3.rs
@@ -1,8 +1,11 @@
 extern crate nalgebra as na;
 
 use na::{Point3, Vector3};
-use rapier3d::dynamics::{JointSet, RigidBodyBuilder, RigidBodySet};
 use rapier3d::geometry::{ColliderBuilder, ColliderSet};
+use rapier3d::{
+    dynamics::{RigidBodyBuilder, RigidBodySet},
+    prelude::{ImpulseJointSet, MultibodyJointSet},
+};
 use rapier_testbed3d::{Testbed, TestbedApp};
 use salva3d::integrations::rapier::{ColliderSampling, FluidsPipeline, FluidsTestbedPlugin};
 use salva3d::object::{Boundary, Fluid};
@@ -23,7 +26,8 @@ pub fn init_world(testbed: &mut Testbed) {
     let gravity = Vector3::y() * -9.81;
     let mut bodies = RigidBodySet::new();
     let mut colliders = ColliderSet::new();
-    let joints = JointSet::new();
+    let impulse_joints = ImpulseJointSet::new();
+    let multibody_joints = MultibodyJointSet::new();
     let mut fluids_pipeline = FluidsPipeline::new(PARTICLE_RADIUS, SMOOTHING_FACTOR);
 
     let ground_rad = 0.15;
@@ -38,7 +42,7 @@ pub fn init_world(testbed: &mut Testbed) {
     plugin.set_fluid_color(fluid_handle, Point3::new(0.5, 1.0, 1.0));
 
     // Setup the ground.
-    let ground_handle = bodies.insert(RigidBodyBuilder::new_static().build());
+    let ground_handle = bodies.insert(RigidBodyBuilder::fixed().build());
     let co = ColliderBuilder::ball(ground_rad).build();
     let ball_samples =
         salva3d::sampling::shape_surface_ray_sample(co.shape(), PARTICLE_RADIUS).unwrap();
@@ -100,7 +104,14 @@ pub fn init_world(testbed: &mut Testbed) {
     plugin.set_pipeline(fluids_pipeline);
     testbed.add_plugin(plugin);
     testbed.set_body_wireframe(ground_handle, true);
-    testbed.set_world_with_params(bodies, colliders, joints, gravity, ());
+    testbed.set_world_with_params(
+        bodies,
+        colliders,
+        impulse_joints,
+        multibody_joints,
+        gravity,
+        (),
+    );
     testbed.integration_parameters_mut().dt = 1.0 / 200.0;
     // testbed.enable_boundary_particles_rendering(true);
     testbed.look_at(Point3::new(1.5, 0.0, 1.5), Point3::new(0.0, 0.0, 0.0));

--- a/examples3d/harness_basic3.rs
+++ b/examples3d/harness_basic3.rs
@@ -1,8 +1,11 @@
 extern crate nalgebra as na;
 
 use na::{Isometry3, Vector3};
-use rapier3d::dynamics::{JointSet, RigidBodyBuilder, RigidBodySet};
 use rapier3d::geometry::{ColliderBuilder, ColliderSet, SharedShape};
+use rapier3d::{
+    dynamics::{RigidBodyBuilder, RigidBodySet},
+    prelude::{ImpulseJointSet, MultibodyJointSet},
+};
 use rapier_testbed3d::harness::Harness;
 use salva3d::integrations::rapier::{ColliderSampling, FluidsHarnessPlugin, FluidsPipeline};
 use salva3d::object::Boundary;
@@ -23,7 +26,8 @@ pub fn init_world(harness: &mut Harness) {
     let gravity = Vector3::y() * -9.81;
     let mut bodies = RigidBodySet::new();
     let mut colliders = ColliderSet::new();
-    let joints = JointSet::new();
+    let impulse_joints = ImpulseJointSet::new();
+    let multibody_joints = MultibodyJointSet::new();
     let mut fluids_pipeline = FluidsPipeline::new(PARTICLE_RADIUS, SMOOTHING_FACTOR);
 
     // Parameters of the ground.
@@ -49,7 +53,7 @@ pub fn init_world(harness: &mut Harness) {
     let ground_shape = SharedShape::cuboid(ground_half_width, ground_thickness, ground_half_width);
     let wall_shape = SharedShape::cuboid(ground_thickness, ground_half_height, ground_half_width);
 
-    let ground_body = RigidBodyBuilder::new_static().build();
+    let ground_body = RigidBodyBuilder::fixed().build();
     let ground_handle = bodies.insert(ground_body);
 
     let wall_poses = [
@@ -103,7 +107,14 @@ pub fn init_world(harness: &mut Harness) {
     let mut plugin = FluidsHarnessPlugin::new();
     plugin.set_pipeline(fluids_pipeline);
     harness.add_plugin(plugin);
-    harness.set_world_with_params(bodies, colliders, joints, gravity, ());
+    harness.set_world_with_params(
+        bodies,
+        colliders,
+        impulse_joints,
+        multibody_joints,
+        gravity,
+        (),
+    );
     harness.integration_parameters_mut().dt = 1.0 / 200.0;
 }
 

--- a/examples3d/heightfield3.rs
+++ b/examples3d/heightfield3.rs
@@ -22,7 +22,8 @@ pub fn init_world(testbed: &mut Testbed) {
      */
     let mut bodies = RigidBodySet::new();
     let mut colliders = ColliderSet::new();
-    let joints = JointSet::new();
+    let impulse_joints = ImpulseJointSet::new();
+    let multibody_joints = MultibodyJointSet::new();
 
     /* Fluid */
     let mut fluids_pipeline = FluidsPipeline::new(PARTICLE_RADIUS, SMOOTHING_FACTOR);
@@ -59,7 +60,7 @@ pub fn init_world(testbed: &mut Testbed) {
         }
     });
 
-    let rigid_body = RigidBodyBuilder::new_static().build();
+    let rigid_body = RigidBodyBuilder::fixed().build();
     let handle = bodies.insert(rigid_body);
     let ground_collider = ColliderBuilder::heightfield(heights.clone(), ground_size).build();
     let ground_handle = colliders.insert_with_parent(ground_collider.clone(), handle, &mut bodies);
@@ -89,6 +90,6 @@ pub fn init_world(testbed: &mut Testbed) {
     /*
      * Set up the testbed.
      */
-    testbed.set_world(bodies, colliders, joints);
+    testbed.set_world(bodies, colliders, impulse_joints, multibody_joints);
     testbed.look_at(point![100.0, 100.0, 100.0], Point::origin());
 }

--- a/examples3d/surface_tension3.rs
+++ b/examples3d/surface_tension3.rs
@@ -1,7 +1,7 @@
 extern crate nalgebra as na;
 
 use na::{Isometry3, Point3, Vector3};
-use rapier3d::dynamics::{JointSet, RigidBodyBuilder, RigidBodySet};
+use rapier3d::dynamics::{ImpulseJointSet, MultibodyJointSet, RigidBodyBuilder, RigidBodySet};
 use rapier3d::geometry::{ColliderBuilder, ColliderSet};
 use rapier_testbed3d::{Testbed, TestbedApp};
 use salva3d::integrations::rapier::{
@@ -27,7 +27,8 @@ pub fn init_world(testbed: &mut Testbed) {
     let mut plugin = FluidsTestbedPlugin::new();
     let mut bodies = RigidBodySet::new();
     let mut colliders = ColliderSet::new();
-    let joints = JointSet::new();
+    let impulse_joints = ImpulseJointSet::new();
+    let multibody_joints = MultibodyJointSet::new();
     let mut fluids_pipeline = FluidsPipeline::new(PARTICLE_RADIUS, SMOOTHING_FACTOR);
 
     /*
@@ -44,7 +45,7 @@ pub fn init_world(testbed: &mut Testbed) {
     plugin.set_fluid_color(fluid_handle, Point3::new(0.8, 0.7, 1.0));
 
     // Setup the ground.
-    let ground_handle = bodies.insert(RigidBodyBuilder::new_static().build());
+    let ground_handle = bodies.insert(RigidBodyBuilder::fixed().build());
 
     let ground_thickness = 0.02;
     let ground_half_width = 0.15;
@@ -69,7 +70,14 @@ pub fn init_world(testbed: &mut Testbed) {
     plugin.set_fluid_rendering_mode(FluidsRenderingMode::VelocityColor { min: 0.0, max: 5.0 });
     testbed.add_plugin(plugin);
     testbed.set_body_wireframe(ground_handle, true);
-    testbed.set_world_with_params(bodies, colliders, joints, gravity, ());
+    testbed.set_world_with_params(
+        bodies,
+        colliders,
+        impulse_joints,
+        multibody_joints,
+        gravity,
+        (),
+    );
     testbed.integration_parameters_mut().dt = 1.0 / 200.0;
     testbed.look_at(Point3::new(0.25, 0.25, 0.25), Point3::origin());
 }

--- a/src/integrations/rapier/fluids_pipeline.rs
+++ b/src/integrations/rapier/fluids_pipeline.rs
@@ -277,7 +277,7 @@ impl<'a> CouplingManager for ColliderCouplingManager<'a> {
                             for (pos, force) in
                                 boundary.positions.iter().zip(forces.iter().cloned())
                             {
-                                body.apply_force_at_point(force, *pos, true)
+                                body.add_force_at_point(force, *pos, true)
                             }
                         }
                     }

--- a/src/integrations/rapier/testbed_plugin.rs
+++ b/src/integrations/rapier/testbed_plugin.rs
@@ -1,16 +1,15 @@
 use crate::math::{Isometry, Point, Real, Rotation, Translation, Vector};
 use crate::object::{BoundaryHandle, FluidHandle};
 use bevy::math::Quat;
-use bevy::prelude::{Assets, Commands, Mesh, Query, StandardMaterial, Transform};
-use bevy_egui::egui::ComboBox;
-use bevy_egui::{egui::Window, EguiContext};
+use bevy::prelude::{Assets, Commands, Mesh, Query, Transform};
+use bevy_egui::{egui::ComboBox, egui::Window, EguiContexts};
 #[cfg(feature = "dim3")]
 use na::Quaternion;
 use na::{Point3, Vector3};
 use parry::shape::SharedShape;
 use rapier_testbed::{
-    harness::Harness, objects::node::EntityWithGraphics, GraphicsManager, PhysicsState,
-    TestbedPlugin,
+    harness::Harness, objects::node::EntityWithGraphics, BevyMaterial, GraphicsManager,
+    PhysicsState, TestbedPlugin,
 };
 
 use crate::integrations::rapier::FluidsPipeline;
@@ -143,7 +142,7 @@ impl FluidsTestbedPlugin {
         graphics: &mut GraphicsManager,
         commands: &mut Commands,
         meshes: &mut Assets<Mesh>,
-        materials: &mut Assets<StandardMaterial>,
+        materials: &mut Assets<BevyMaterial>,
         _components: &mut Query<(&mut Transform,)>,
         _harness: &mut Harness,
         color: &Point3<f32>,
@@ -201,22 +200,28 @@ impl FluidsTestbedPlugin {
 }
 
 impl TestbedPlugin for FluidsTestbedPlugin {
+    fn init_plugin(&mut self) {
+        // TODO: decide if anything needs to be changed
+    }
+
     fn init_graphics(
         &mut self,
         graphics: &mut GraphicsManager,
         commands: &mut Commands,
         meshes: &mut Assets<Mesh>,
-        materials: &mut Assets<StandardMaterial>,
+        materials: &mut Assets<BevyMaterial>,
         components: &mut Query<(&mut Transform,)>,
         harness: &mut Harness,
-        gen_color: &mut dyn FnMut() -> Point3<f32>,
     ) {
         for (handle, fluid) in self.fluids_pipeline.liquid_world.fluids().iter() {
             let _ = self
                 .f2sn
                 .insert(handle, Vec::with_capacity(fluid.positions.len()));
 
-            let color = *self.f2color.entry(handle).or_insert_with(|| gen_color());
+            let color = *self
+                .f2color
+                .entry(handle)
+                .or_insert_with(|| self.default_fluid_color);
 
             for particle in &fluid.positions {
                 let ent = self.add_particle_graphics(
@@ -342,22 +347,13 @@ impl TestbedPlugin for FluidsTestbedPlugin {
         graphics: &mut GraphicsManager,
         commands: &mut Commands,
         meshes: &mut Assets<Mesh>,
-        materials: &mut Assets<StandardMaterial>,
+        materials: &mut Assets<BevyMaterial>,
         components: &mut Query<(&mut Transform,)>,
         harness: &mut Harness,
     ) {
-        let default_color = self.default_fluid_color;
         if self.queue_graphics_reset {
             self.clear_graphics(graphics, commands);
-            self.init_graphics(
-                graphics,
-                commands,
-                meshes,
-                materials,
-                components,
-                harness,
-                &mut || default_color,
-            );
+            self.init_graphics(graphics, commands, meshes, materials, components, harness);
             self.queue_graphics_reset = false;
         }
 
@@ -448,7 +444,7 @@ impl TestbedPlugin for FluidsTestbedPlugin {
                                 }
                             }
                         }
-                        entity.update(&harness.physics.colliders, components)
+                        entity.update(&harness.physics.colliders, components, &graphics.gfx_shift)
                     }
                 }
             }
@@ -457,12 +453,12 @@ impl TestbedPlugin for FluidsTestbedPlugin {
 
     fn update_ui(
         &mut self,
-        ui_context: &EguiContext,
+        ui_context: &EguiContexts,
         harness: &mut Harness,
         graphics: &mut GraphicsManager,
         commands: &mut Commands,
         meshes: &mut Assets<Mesh>,
-        materials: &mut Assets<StandardMaterial>,
+        materials: &mut Assets<BevyMaterial>,
         components: &mut Query<(&mut Transform,)>,
     ) {
         fn get_rendering_mode_index(rendering_mode: FluidsRenderingMode) -> usize {
@@ -488,7 +484,7 @@ impl TestbedPlugin for FluidsTestbedPlugin {
                     .show_ui(ui, |ui| {
                         for (_, (name, mode)) in FLUIDS_RENDERING_MAP.iter().enumerate() {
                             changed = ui
-                                .selectable_value(&mut self.fluids_rendering_mode, *mode, name)
+                                .selectable_value(&mut self.fluids_rendering_mode, *mode, *name)
                                 .changed()
                                 || changed;
                         }
@@ -496,25 +492,17 @@ impl TestbedPlugin for FluidsTestbedPlugin {
 
                 if changed {
                     // FIXME: not too sure what to do here for color
-                    let fluid_handle = self
-                        .fluids_pipeline
-                        .liquid_world
-                        .fluids()
-                        .iter()
-                        .next()
-                        .unwrap()
-                        .0;
+                    // let fluid_handle = self
+                    //     .fluids_pipeline
+                    //     .liquid_world
+                    //     .fluids()
+                    //     .iter()
+                    //     .next()
+                    //     .unwrap()
+                    //     .0;
                     self.clear_graphics(graphics, commands);
-                    let color = self.f2color[&fluid_handle].clone();
-                    self.init_graphics(
-                        graphics,
-                        commands,
-                        meshes,
-                        materials,
-                        components,
-                        harness,
-                        &mut || color,
-                    )
+                    // let color = self.f2color[&fluid_handle].clone();
+                    self.init_graphics(graphics, commands, meshes, materials, components, harness)
                 }
             });
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,8 +107,8 @@ pub use crate::timestep_manager::TimestepManager;
 #[cfg(feature = "dim3")]
 pub mod math {
     use na::{
-        Isometry3, Matrix3, Matrix6, Matrix6xX, MatrixSlice6xX, MatrixSliceMut6xX, Point3,
-        Rotation3, Translation3, UnitQuaternion, Vector3, Vector6, U3, U6,
+        Isometry3, Matrix3, Matrix6, Matrix6xX, MatrixView6xX, MatrixViewMut6xX, Point3, Rotation3,
+        Translation3, UnitQuaternion, Vector3, Vector6, U3, U6,
     };
 
     /// The maximum number of possible rotations and translations of a rigid body.
@@ -173,10 +173,10 @@ pub mod math {
     pub type Jacobian<Real> = Matrix6xX<Real>;
 
     /// The type of a slice of the constraint jacobian in twist coordinates.
-    pub type JacobianSlice<'a, Real> = MatrixSlice6xX<'a, Real>;
+    pub type JacobianSlice<'a, Real> = MatrixView6xX<'a, Real>;
 
     /// The type of a mutable slice of the constraint jacobian in twist coordinates.
-    pub type JacobianSliceMut<'a, Real> = MatrixSliceMut6xX<'a, Real>;
+    pub type JacobianSliceMut<'a, Real> = MatrixViewMut6xX<'a, Real>;
 
     /// The cross-product matrix for the given vector.
     pub fn gcross_matrix(v: &Vector<Real>) -> Matrix<Real> {
@@ -188,7 +188,7 @@ pub mod math {
 #[cfg(feature = "dim2")]
 pub mod math {
     use na::{
-        Isometry2, Matrix1, Matrix2, Matrix3, Matrix6xX, MatrixSlice3xX, MatrixSliceMut3xX, Point2,
+        Isometry2, Matrix1, Matrix2, Matrix3, Matrix6xX, MatrixView3xX, MatrixViewMut3xX, Point2,
         Rotation2, RowVector2, Translation2, UnitComplex, Vector1, Vector2, Vector3, U1, U2, U3,
     };
 
@@ -254,10 +254,10 @@ pub mod math {
     pub type Jacobian<Real> = Matrix6xX<Real>;
 
     /// The type of a slice of the constraint jacobian in twist coordinates.
-    pub type JacobianSlice<'a, Real> = MatrixSlice3xX<'a, Real>;
+    pub type JacobianSlice<'a, Real> = MatrixView3xX<'a, Real>;
 
     /// The type of a mutable slice of the constraint jacobian in twist coordinates.
-    pub type JacobianSliceMut<'a, Real> = MatrixSliceMut3xX<'a, Real>;
+    pub type JacobianSliceMut<'a, Real> = MatrixViewMut3xX<'a, Real>;
 
     /// The cross-product matrix for the given vector, generalized in 2D.
     pub fn gcross_matrix(v: &Vector<Real>) -> RowVector2<Real> {

--- a/src/liquid_world.rs
+++ b/src/liquid_world.rs
@@ -10,7 +10,7 @@ use crate::TimestepManager;
 use {
     crate::math::Isometry,
     crate::object::ParticleId,
-    parry::{bounding_volume::AABB, query::PointQuery, shape::Shape},
+    parry::{bounding_volume::Aabb, query::PointQuery, shape::Shape},
 };
 
 /// The physics world for simulating fluids with boundaries.
@@ -211,7 +211,7 @@ impl LiquidWorld {
     #[cfg(feature = "parry")]
     pub fn particles_intersecting_aabb<'a>(
         &'a self,
-        aabb: AABB,
+        aabb: Aabb,
     ) -> impl Iterator<Item = ParticleId> + 'a {
         self.hgrid
             .cells_intersecting_aabb(&aabb.mins, &aabb.maxs)

--- a/src/sampling/ray_sampling.rs
+++ b/src/sampling/ray_sampling.rs
@@ -1,6 +1,6 @@
 use crate::math::{Isometry, Point, Real, Vector, DIM};
 
-use parry::bounding_volume::{BoundingVolume, AABB};
+use parry::bounding_volume::{Aabb, BoundingVolume};
 use parry::query::{Ray, RayCast};
 use rapier::geometry::Shape;
 use std::collections::HashSet;
@@ -26,7 +26,7 @@ pub fn shape_volume_ray_sample<S: ?Sized + Shape>(
 /// Samples the surface of `shape` with a method based on ray-casting.
 pub fn surface_ray_sample<S: ?Sized + RayCast>(
     shape: &S,
-    volume: &AABB,
+    volume: &Aabb,
     particle_rad: Real,
 ) -> Vec<Point<Real>> {
     let mut quantized_points = HashSet::new();
@@ -90,7 +90,7 @@ pub fn surface_ray_sample<S: ?Sized + RayCast>(
 /// Samples the volume of `shape` with a method based on ray-casting.
 pub fn volume_ray_sample<S: ?Sized + RayCast>(
     shape: &S,
-    volume: &AABB,
+    volume: &Aabb,
     particle_rad: Real,
 ) -> Vec<Point<Real>> {
     let mut quantized_points = HashSet::new();


### PR DESCRIPTION
This supersedes #42 and has the same goals. A few cargo patches are used to pull in testbed versions that are up to date (published testbed still targets bevy 0.9, upstream is up to 0.12). Additionally, I bumped the edition floor to enable more features for down the road.

All examples were tested and seem to work correctly.