### PR TITLE
Update dependencies

### DIFF
--- a/build/salva2d/Cargo.toml
+++ b/build/salva2d/Cargo.toml
@@ -41,10 +41,10 @@ generational-arena = "0.2"
 instant = { version = "0.1", features = [ "now" ] }
 rayon = { version = "1.8", optional = true }
 
-nalgebra  = "0.32"
-parry2d = { version = "0.15", optional = true }
-rapier2d = { version = "0.20", optional = true }
-rapier_testbed2d = { version = "0.20", optional = true }
+nalgebra = "0.33"
+parry2d = { version = "0.16", optional = true }
+rapier2d = { version = "0.21", optional = true }
+rapier_testbed2d = { version = "0.21", optional = true }
 
 bevy_egui = { version = "0.26", features = ["immutable_ctx"], optional = true }
 

--- a/build/salva2d/Cargo.toml
+++ b/build/salva2d/Cargo.toml
@@ -36,21 +36,21 @@ required-features = [ "dim2" ]
 approx = "0.5"
 num-traits = "0.2"
 fnv = "1.0"
-itertools = "0.13.0"
+itertools = "0.13"
 generational-arena = "0.2"
 instant = { version = "0.1", features = [ "now" ] }
 rayon = { version = "1.8", optional = true }
 
 nalgebra  = "0.32"
-parry2d = { version = "0.15.1", optional = true }
-rapier2d = { version = "0.20.0", optional = true }
-rapier_testbed2d = { version = "0.20.0", optional = true }
+parry2d = { version = "0.15", optional = true }
+rapier2d = { version = "0.20", optional = true }
+rapier_testbed2d = { version = "0.20", optional = true }
 
-bevy_egui = { version = "0.26.0", features = ["immutable_ctx"], optional = true }
+bevy_egui = { version = "0.26", features = ["immutable_ctx"], optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 bevy = { version = "0.13.2", default-features = false, features = ["bevy_winit", "bevy_render", "x11"], optional = true }
 
 # Dependencies for WASM only.
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-bevy = { version = "0.13.2", default-features = false, features = ["bevy_winit", "bevy_render"], optional = true }
+bevy = { version = "0.13", default-features = false, features = ["bevy_winit", "bevy_render"], optional = true }

--- a/build/salva2d/Cargo.toml
+++ b/build/salva2d/Cargo.toml
@@ -36,21 +36,21 @@ required-features = [ "dim2" ]
 approx = "0.5"
 num-traits = "0.2"
 fnv = "1.0"
-itertools = "0.12"
+itertools = "0.13.0"
 generational-arena = "0.2"
 instant = { version = "0.1", features = [ "now" ] }
 rayon = { version = "1.8", optional = true }
 
 nalgebra  = "0.32"
-parry2d = { version = "0.13", optional = true }
-rapier2d = { version = "0.18", optional = true }
-rapier_testbed2d = { version = "0.18", optional = true }
+parry2d = { version = "0.15.1", optional = true }
+rapier2d = { version = "0.20.0", optional = true }
+rapier_testbed2d = { version = "0.20.0", optional = true }
 
-bevy_egui = { version = "0.23", features = ["immutable_ctx"], optional = true }
+bevy_egui = { version = "0.26.0", features = ["immutable_ctx"], optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-bevy = { version = "0.12.1", default-features = false, features = ["bevy_winit", "bevy_render", "x11"], optional = true }
+bevy = { version = "0.13.2", default-features = false, features = ["bevy_winit", "bevy_render", "x11"], optional = true }
 
 # Dependencies for WASM only.
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-bevy = { version = "0.12", default-features = false, features = ["bevy_winit", "bevy_render"], optional = true }
+bevy = { version = "0.13.2", default-features = false, features = ["bevy_winit", "bevy_render"], optional = true }

--- a/build/salva3d/Cargo.toml
+++ b/build/salva3d/Cargo.toml
@@ -32,21 +32,21 @@ required-features = [ "dim3" ]
 approx = "0.5"
 num-traits = "0.2"
 fnv = "1.0"
-itertools = "0.12"
+itertools = "0.13.0"
 generational-arena = "0.2"
 instant = { version = "0.1", features = [ "now" ] }
 rayon = { version = "1.8", optional = true }
 
 nalgebra  = "0.32"
-parry3d = { version = "0.13", optional = true }
-rapier3d = { version = "0.18", optional = true }
-rapier_testbed3d = { version = "0.18", optional = true }
+parry3d = { version = "0.15.1", optional = true }
+rapier3d = { version = "0.20.0", optional = true }
+rapier_testbed3d = { version = "0.20.0", optional = true }
 
-bevy_egui = { version = "0.23", features = ["immutable_ctx"], optional = true }
+bevy_egui = { version = "0.26.0", features = ["immutable_ctx"], optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-bevy = { version = "0.12", default-features = false, features = ["bevy_winit", "bevy_render", "x11"], optional = true }
+bevy = { version = "0.13.2", default-features = false, features = ["bevy_winit", "bevy_render", "x11"], optional = true }
 
 # Dependencies for WASM only.
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-bevy = { version = "0.12", default-features = false, features = ["bevy_winit", "bevy_render"], optional = true }
+bevy = { version = "0.13.2", default-features = false, features = ["bevy_winit", "bevy_render"], optional = true }

--- a/build/salva3d/Cargo.toml
+++ b/build/salva3d/Cargo.toml
@@ -32,21 +32,21 @@ required-features = [ "dim3" ]
 approx = "0.5"
 num-traits = "0.2"
 fnv = "1.0"
-itertools = "0.13.0"
+itertools = "0.13"
 generational-arena = "0.2"
 instant = { version = "0.1", features = [ "now" ] }
 rayon = { version = "1.8", optional = true }
 
 nalgebra  = "0.32"
-parry3d = { version = "0.15.1", optional = true }
-rapier3d = { version = "0.20.0", optional = true }
-rapier_testbed3d = { version = "0.20.0", optional = true }
+parry3d = { version = "0.15", optional = true }
+rapier3d = { version = "0.20", optional = true }
+rapier_testbed3d = { version = "0.20", optional = true }
 
-bevy_egui = { version = "0.26.0", features = ["immutable_ctx"], optional = true }
+bevy_egui = { version = "0.26", features = ["immutable_ctx"], optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-bevy = { version = "0.13.2", default-features = false, features = ["bevy_winit", "bevy_render", "x11"], optional = true }
+bevy = { version = "0.13", default-features = false, features = ["bevy_winit", "bevy_render", "x11"], optional = true }
 
 # Dependencies for WASM only.
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-bevy = { version = "0.13.2", default-features = false, features = ["bevy_winit", "bevy_render"], optional = true }
+bevy = { version = "0.13", default-features = false, features = ["bevy_winit", "bevy_render"], optional = true }

--- a/build/salva3d/Cargo.toml
+++ b/build/salva3d/Cargo.toml
@@ -37,10 +37,10 @@ generational-arena = "0.2"
 instant = { version = "0.1", features = [ "now" ] }
 rayon = { version = "1.8", optional = true }
 
-nalgebra  = "0.32"
-parry3d = { version = "0.15", optional = true }
-rapier3d = { version = "0.20", optional = true }
-rapier_testbed3d = { version = "0.20", optional = true }
+nalgebra = "0.33"
+parry3d = { version = "0.16", optional = true }
+rapier3d = { version = "0.21", optional = true }
+rapier_testbed3d = { version = "0.21", optional = true }
 
 bevy_egui = { version = "0.26", features = ["immutable_ctx"], optional = true }
 

--- a/examples2d/Cargo.toml
+++ b/examples2d/Cargo.toml
@@ -10,11 +10,11 @@ parallel = [ "rapier_testbed2d/parallel"]
 
 [dependencies]
 Inflector  = "0.11"
-nalgebra   = "0.32"
-parry2d = "0.15"
-rapier2d = "0.20"
-rapier_testbed2d = "0.20"
-parry3d = "0.15"
+nalgebra   = "0.33"
+parry2d = "0.16"
+rapier2d = "0.21"
+rapier_testbed2d = "0.21"
+parry3d = "0.16"
 bevy = "0.13.2"
 
 [dependencies.salva2d]

--- a/examples2d/Cargo.toml
+++ b/examples2d/Cargo.toml
@@ -11,11 +11,11 @@ parallel = [ "rapier_testbed2d/parallel"]
 [dependencies]
 Inflector  = "0.11"
 nalgebra   = "0.32"
-parry2d = "0.13"
-rapier2d = "0.18"
-rapier_testbed2d = "0.18"
-parry3d = "0.13"
-bevy = "0.12.1"
+parry2d = "0.15.1"
+rapier2d = "0.20.0"
+rapier_testbed2d = "0.20.0"
+parry3d = "0.15.1"
+bevy = "0.13.2"
 
 [dependencies.salva2d]
 path = "../build/salva2d"

--- a/examples2d/Cargo.toml
+++ b/examples2d/Cargo.toml
@@ -11,10 +11,10 @@ parallel = [ "rapier_testbed2d/parallel"]
 [dependencies]
 Inflector  = "0.11"
 nalgebra   = "0.32"
-parry2d = "0.15.1"
-rapier2d = "0.20.0"
-rapier_testbed2d = "0.20.0"
-parry3d = "0.15.1"
+parry2d = "0.15"
+rapier2d = "0.20"
+rapier_testbed2d = "0.20"
+parry3d = "0.15"
 bevy = "0.13.2"
 
 [dependencies.salva2d]

--- a/examples3d/Cargo.toml
+++ b/examples3d/Cargo.toml
@@ -11,10 +11,10 @@ parallel = [ "rapier_testbed3d/parallel", "salva3d/parallel"]
 [dependencies]
 num-traits = "0.2"
 Inflector  = "0.11"
-nalgebra   = "0.32"
-rapier3d = "0.20"
-rapier_testbed3d = "0.20"
-parry3d = "0.15"
+nalgebra   = "0.33"
+rapier3d = "0.21"
+rapier_testbed3d = "0.21"
+parry3d = "0.16"
 bevy = "0.13.2"
 
 [dependencies.salva3d]

--- a/examples3d/Cargo.toml
+++ b/examples3d/Cargo.toml
@@ -12,9 +12,9 @@ parallel = [ "rapier_testbed3d/parallel", "salva3d/parallel"]
 num-traits = "0.2"
 Inflector  = "0.11"
 nalgebra   = "0.32"
-rapier3d = "0.20.0"
-rapier_testbed3d = "0.20.0"
-parry3d = "0.15.1"
+rapier3d = "0.20"
+rapier_testbed3d = "0.20"
+parry3d = "0.15"
 bevy = "0.13.2"
 
 [dependencies.salva3d]

--- a/examples3d/Cargo.toml
+++ b/examples3d/Cargo.toml
@@ -12,10 +12,10 @@ parallel = [ "rapier_testbed3d/parallel", "salva3d/parallel"]
 num-traits = "0.2"
 Inflector  = "0.11"
 nalgebra   = "0.32"
-rapier3d = "0.18"
-rapier_testbed3d = "0.18"
-parry3d = "0.13"
-bevy = "0.12.1"
+rapier3d = "0.20.0"
+rapier_testbed3d = "0.20.0"
+parry3d = "0.15.1"
+bevy = "0.13.2"
 
 [dependencies.salva3d]
 path = "../build/salva3d"

--- a/src/integrations/rapier/testbed_plugin.rs
+++ b/src/integrations/rapier/testbed_plugin.rs
@@ -366,9 +366,7 @@ impl TestbedPlugin for FluidsTestbedPlugin {
                     min = min.min(magnitude);
                     max = max.max(magnitude);
                     if let Some(entity) = entities.get_mut(idx) {
-                        if let Ok(mut pos) =
-                            components.get_mut(entity.entity)
-                        {
+                        if let Ok(mut pos) = components.get_mut(entity.entity) {
                             {
                                 pos.translation.x = particle.x;
                                 pos.translation.y = particle.y;

--- a/src/integrations/rapier/testbed_plugin.rs
+++ b/src/integrations/rapier/testbed_plugin.rs
@@ -143,7 +143,7 @@ impl FluidsTestbedPlugin {
         commands: &mut Commands,
         meshes: &mut Assets<Mesh>,
         materials: &mut Assets<BevyMaterial>,
-        _components: &mut Query<(&mut Transform,)>,
+        _components: &mut Query<&mut Transform>,
         _harness: &mut Harness,
         color: &Point3<f32>,
         force_shape: Option<SharedShape>,
@@ -210,7 +210,7 @@ impl TestbedPlugin for FluidsTestbedPlugin {
         commands: &mut Commands,
         meshes: &mut Assets<Mesh>,
         materials: &mut Assets<BevyMaterial>,
-        components: &mut Query<(&mut Transform,)>,
+        components: &mut Query<&mut Transform>,
         harness: &mut Harness,
     ) {
         for (handle, fluid) in self.fluids_pipeline.liquid_world.fluids().iter() {
@@ -348,7 +348,7 @@ impl TestbedPlugin for FluidsTestbedPlugin {
         commands: &mut Commands,
         meshes: &mut Assets<Mesh>,
         materials: &mut Assets<BevyMaterial>,
-        components: &mut Query<(&mut Transform,)>,
+        components: &mut Query<&mut Transform>,
         harness: &mut Harness,
     ) {
         if self.queue_graphics_reset {
@@ -367,7 +367,7 @@ impl TestbedPlugin for FluidsTestbedPlugin {
                     max = max.max(magnitude);
                     if let Some(entity) = entities.get_mut(idx) {
                         if let Ok(mut pos) =
-                            components.get_component_mut::<Transform>(entity.entity)
+                            components.get_mut(entity.entity)
                         {
                             {
                                 pos.translation.x = particle.x;
@@ -459,7 +459,7 @@ impl TestbedPlugin for FluidsTestbedPlugin {
         commands: &mut Commands,
         meshes: &mut Assets<Mesh>,
         materials: &mut Assets<BevyMaterial>,
-        components: &mut Query<(&mut Transform,)>,
+        components: &mut Query<&mut Transform>,
     ) {
         fn get_rendering_mode_index(rendering_mode: FluidsRenderingMode) -> usize {
             FLUIDS_RENDERING_MAP

--- a/src/z_order.rs
+++ b/src/z_order.rs
@@ -10,7 +10,7 @@ pub fn compute_points_z_order(points: &[Point<Real>]) -> Vec<usize> {
     let mut indices: Vec<_> = (0..points.len()).collect();
     indices.sort_unstable_by(|i, j| {
         z_order_floats(points[*i].coords.as_slice(), points[*j].coords.as_slice())
-            .unwrap_or(std::cmp::Ordering::Equal)
+            .unwrap_or(Ordering::Equal)
     });
     indices
 }


### PR DESCRIPTION
This updates most of the dependencies to latest, except for `bevy_egui`, which is updated to `0.26.0` because `rapier_testbed*` is still on a old version.