### PR TITLE
add `opt-level = 1` for dev profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,10 @@ resolver = "2"
 #lto = true
 #codegen-units = 1
 
+[profile.dev]
+# Use slightly better optimization by default, as examples otherwise seem laggy.
+opt-level = 1
+
 [patch.crates-io]
 salva2d = { path = "./build/salva2d" }
 salva3d = { path = "./build/salva3d" }


### PR DESCRIPTION
I noticed examples were quite laggy on my example, as rapier and bevy_rapier also have this `opt-level = 1` in their worspace `Cargo.toml`, it makes sense to add them on salva too.