### PR TITLE
Replace instant by web-time

### DIFF
--- a/build/salva2d/Cargo.toml
+++ b/build/salva2d/Cargo.toml
@@ -38,7 +38,7 @@ num-traits = "0.2"
 fnv = "1.0"
 itertools = "0.13"
 generational-arena = "0.2"
-instant = { version = "0.1", features = [ "now" ] }
+web-time = { version = "1.1" }
 rayon = { version = "1.8", optional = true }
 
 nalgebra = "0.33"

--- a/build/salva3d/Cargo.toml
+++ b/build/salva3d/Cargo.toml
@@ -34,7 +34,7 @@ num-traits = "0.2"
 fnv = "1.0"
 itertools = "0.13"
 generational-arena = "0.2"
-instant = { version = "0.1", features = [ "now" ] }
+web-time = { version = "1.1" }
 rayon = { version = "1.8", optional = true }
 
 nalgebra = "0.33"

--- a/src/counters/timer.rs
+++ b/src/counters/timer.rs
@@ -6,7 +6,7 @@ use web_time::Instant;
 pub struct Timer {
     enabled: bool,
     time: f64,
-    start: Option<f64>,
+    start: Option<Instant>,
 }
 
 impl Timer {
@@ -38,7 +38,7 @@ impl Timer {
     pub fn start(&mut self) {
         if self.enabled {
             self.time = 0.0;
-            self.start = Some(Instant::now().elapsed().as_secs_f64());
+            self.start = Some(Instant::now());
         }
     }
 
@@ -46,7 +46,7 @@ impl Timer {
     pub fn pause(&mut self) {
         if self.enabled {
             if let Some(start) = self.start {
-                self.time += Instant::now().elapsed().as_secs_f64() - start;
+                self.time += start.elapsed().as_secs_f64();
             }
             self.start = None;
         }
@@ -55,7 +55,7 @@ impl Timer {
     /// Resume the timer.
     pub fn resume(&mut self) {
         if self.enabled {
-            self.start = Some(Instant::now().elapsed().as_secs_f64());
+            self.start = Some(Instant::now());
         }
     }
 

--- a/src/counters/timer.rs
+++ b/src/counters/timer.rs
@@ -1,4 +1,5 @@
 use std::fmt::{Display, Error, Formatter};
+use web_time::Instant;
 
 /// A timer.
 #[derive(Copy, Clone, Debug, Default)]
@@ -37,7 +38,7 @@ impl Timer {
     pub fn start(&mut self) {
         if self.enabled {
             self.time = 0.0;
-            self.start = Some(instant::now());
+            self.start = Some(Instant::now().elapsed().as_secs_f64());
         }
     }
 
@@ -45,7 +46,7 @@ impl Timer {
     pub fn pause(&mut self) {
         if self.enabled {
             if let Some(start) = self.start {
-                self.time += instant::now() - start;
+                self.time += Instant::now().elapsed().as_secs_f64() - start;
             }
             self.start = None;
         }
@@ -54,7 +55,7 @@ impl Timer {
     /// Resume the timer.
     pub fn resume(&mut self) {
         if self.enabled {
-            self.start = Some(instant::now());
+            self.start = Some(Instant::now().elapsed().as_secs_f64());
         }
     }
 

--- a/src/integrations/rapier/harness_plugin.rs
+++ b/src/integrations/rapier/harness_plugin.rs
@@ -58,7 +58,7 @@ impl HarnessPlugin for FluidsHarnessPlugin {
     }
 
     fn step(&mut self, physics: &mut PhysicsState, _run_state: &RunState) {
-        let step_time = Instant::now().elapsed().as_secs_f64();
+        let step_time = Instant::now();
         let dt = physics.integration_parameters.dt;
         self.fluids_pipeline.step(
             &physics.gravity,
@@ -67,7 +67,7 @@ impl HarnessPlugin for FluidsHarnessPlugin {
             &mut physics.bodies,
         );
 
-        self.step_time = Instant::now().elapsed().as_secs_f64() - step_time;
+        self.step_time = step_time.elapsed().as_secs_f64();
     }
 
     fn profiling_string(&self) -> String {

--- a/src/integrations/rapier/harness_plugin.rs
+++ b/src/integrations/rapier/harness_plugin.rs
@@ -2,6 +2,7 @@ use super::FluidsPipeline;
 use rapier_testbed::harness::RunState;
 use rapier_testbed::physics::PhysicsEvents;
 use rapier_testbed::{HarnessPlugin, PhysicsState};
+use web_time::Instant;
 
 /// A user-defined callback executed at each frame.
 pub type FluidCallback =
@@ -57,7 +58,7 @@ impl HarnessPlugin for FluidsHarnessPlugin {
     }
 
     fn step(&mut self, physics: &mut PhysicsState, _run_state: &RunState) {
-        let step_time = instant::now();
+        let step_time = Instant::now().elapsed().as_secs_f64();
         let dt = physics.integration_parameters.dt;
         self.fluids_pipeline.step(
             &physics.gravity,
@@ -66,7 +67,7 @@ impl HarnessPlugin for FluidsHarnessPlugin {
             &mut physics.bodies,
         );
 
-        self.step_time = instant::now() - step_time;
+        self.step_time = Instant::now().elapsed().as_secs_f64() - step_time;
     }
 
     fn profiling_string(&self) -> String {

--- a/src/integrations/rapier/testbed_plugin.rs
+++ b/src/integrations/rapier/testbed_plugin.rs
@@ -331,7 +331,7 @@ impl TestbedPlugin for FluidsTestbedPlugin {
     }
 
     fn step(&mut self, physics: &mut PhysicsState) {
-        let step_time = Instant::now().elapsed().as_secs_f64();
+        let step_time = Instant::now();
         let dt = physics.integration_parameters.dt;
         self.fluids_pipeline.step(
             &physics.gravity,
@@ -340,7 +340,7 @@ impl TestbedPlugin for FluidsTestbedPlugin {
             &mut physics.bodies,
         );
 
-        self.step_time = Instant::now().elapsed().as_secs_f64() - step_time;
+        self.step_time = step_time.elapsed().as_secs_f64();
     }
 
     fn draw(

--- a/src/integrations/rapier/testbed_plugin.rs
+++ b/src/integrations/rapier/testbed_plugin.rs
@@ -14,6 +14,7 @@ use rapier_testbed::{
 
 use crate::integrations::rapier::FluidsPipeline;
 use std::collections::HashMap;
+use web_time::Instant;
 
 //FIXME: handle this with macros, or use bevy-inspectable-egui
 pub const FLUIDS_RENDERING_MAP: [(&str, FluidsRenderingMode); 3] = [
@@ -330,7 +331,7 @@ impl TestbedPlugin for FluidsTestbedPlugin {
     }
 
     fn step(&mut self, physics: &mut PhysicsState) {
-        let step_time = instant::now();
+        let step_time = Instant::now().elapsed().as_secs_f64();
         let dt = physics.integration_parameters.dt;
         self.fluids_pipeline.step(
             &physics.gravity,
@@ -339,7 +340,7 @@ impl TestbedPlugin for FluidsTestbedPlugin {
             &mut physics.bodies,
         );
 
-        self.step_time = instant::now() - step_time;
+        self.step_time = Instant::now().elapsed().as_secs_f64() - step_time;
     }
 
     fn draw(


### PR DESCRIPTION
TODO: I'll want a changelog line once https://github.com/dimforge/salva/pull/54 is merged

To be noted instant is still used somewhere in the dependencies, mostly optionally and through rapier_testbed

<details><summary>Details</summary>
<p>

```txt
$ cargo tree -i instant
instant v0.1.13
├── rapier2d v0.21.0
│   ├── examples2d v0.1.0 (C:\Users\thier\Documents\pro\clients\foresight\projects\salva\examples2d)
│   ├── rapier_testbed2d v0.21.0
│   │   ├── examples2d v0.1.0 (C:\Users\thier\Documents\pro\clients\foresight\projects\salva\examples2d)
│   │   └── salva2d v0.9.0 (C:\Users\thier\Documents\pro\clients\foresight\projects\salva\build\salva2d)
│   │       └── examples2d v0.1.0 (C:\Users\thier\Documents\pro\clients\foresight\projects\salva\examples2d)
│   └── salva2d v0.9.0 (C:\Users\thier\Documents\pro\clients\foresight\projects\salva\build\salva2d) (*)
├── rapier3d v0.21.0
│   ├── examples3d v0.1.0 (C:\Users\thier\Documents\pro\clients\foresight\projects\salva\examples3d)
│   ├── rapier_testbed3d v0.21.0
│   │   ├── examples3d v0.1.0 (C:\Users\thier\Documents\pro\clients\foresight\projects\salva\examples3d)
│   │   └── salva3d v0.9.0 (C:\Users\thier\Documents\pro\clients\foresight\projects\salva\build\salva3d)
│   │       └── examples3d v0.1.0 (C:\Users\thier\Documents\pro\clients\foresight\projects\salva\examples3d)
│   └── salva3d v0.9.0 (C:\Users\thier\Documents\pro\clients\foresight\projects\salva\build\salva3d) (*)
├── rapier_testbed2d v0.21.0 (*)
└── rapier_testbed3d v0.21.0 (*)
```

</p>
</details> 