### PR TITLE
Inset boundary particles during dynamic collider sampling

### DIFF
--- a/src/integrations/rapier/fluids_pipeline.rs
+++ b/src/integrations/rapier/fluids_pipeline.rs
@@ -126,7 +126,7 @@ impl ColliderCouplingSet {
         &'a mut self,
         colliders: &'a ColliderSet,
         bodies: &'a mut RigidBodySet,
-    ) -> ColliderCouplingManager {
+    ) -> ColliderCouplingManager<'a> {
         ColliderCouplingManager {
             coupling: self,
             colliders,


### PR DESCRIPTION
When switching the dynamic bodies in the simple2.rs example to use dynamic collider sampling, the result looks like there is an invisible force field surrounding the objects:

![screenshot_25-01-15_09:50:00](https://github.com/user-attachments/assets/d10d0c37-f84d-4b40-8f60-30859f856b59)

This is happening because boundary particles are placed precisely on the collider surface, so they protrude by the particle radius, making the body behave as if it was bigger.

This PR insets these boundary particles by their radius along the computed normal, which fixes that problem and makes the colliders roughly match the static sampling that is used for them by default.

It does come with a drawback though: particles now have an easier time slipping out of concave shapes with zero thickness, such as the heightfield used by the examples, so now there's some fluid leakage.

![screenshot_25-01-15_09:49:02](https://github.com/user-attachments/assets/13b13bac-7191-49a8-bacd-43baad874d88)
